### PR TITLE
v0.3.2: thread-safety, callback fix, robust body read, security docs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "nl.rogro82.pipup"
         minSdkVersion 24
         targetSdkVersion 34
-        versionCode 15
-        versionName "0.3.1"
+        versionCode 16
+        versionName "0.3.2"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
@@ -35,9 +35,12 @@ class PiPupService : Service(), WebServer.Handler {
     private val mHandler: Handler = Handler(Looper.getMainLooper())
     private var mOverlay: FrameLayout? = null
     private var mPopup: PopupView? = null
-    private var mCurrentProps: PopupProps? = null
-    private var mShownAt: Long = 0L
-    private var mPopupsShown: Long = 0L
+    // Written on the main thread, read by the NanoHTTPD worker thread in /state:
+    // @Volatile / atomics guarantee the HTTP reader sees a consistent, published
+    // value instead of a torn or stale one (the sensors HA polls feed off this).
+    @Volatile private var mCurrentProps: PopupProps? = null
+    @Volatile private var mShownAt: Long = 0L
+    private val mPopupsShown = java.util.concurrent.atomic.AtomicLong(0)
     private val mStartedAt: Long = SystemClock.elapsedRealtime()
     private lateinit var mWebServer: WebServer
 
@@ -45,7 +48,7 @@ class PiPupService : Service(), WebServer.Handler {
     private var mNsdListener: NsdManager.RegistrationListener? = null
 
     private val mWatchdogHandler = Handler(Looper.getMainLooper())
-    private var mWatchdogCleanups: Long = 0L
+    private val mWatchdogCleanups = java.util.concurrent.atomic.AtomicLong(0)
 
     private var mTts: TextToSpeech? = null
     private var mTtsReady = false
@@ -298,7 +301,7 @@ class PiPupService : Service(), WebServer.Handler {
                 try {
                     if (mCurrentProps == null && (mOverlay != null || mPopup != null)) {
                         Log.w(LOG_TAG, "Watchdog: stale overlay without active popup, force removing")
-                        mWatchdogCleanups++
+                        mWatchdogCleanups.incrementAndGet()
                         removePopup(true)
                     }
                 } catch (ex: Throwable) {
@@ -400,7 +403,10 @@ class PiPupService : Service(), WebServer.Handler {
                 mPopup = PopupView.build(this, popup)
 
                 mPopup?.onButton = { btn ->
-                    sendButtonCallback(popup, btn)
+                    // Use the currently shown props, not this closure's `popup`:
+                    // an update-in-place reuses the view but can carry a new
+                    // callback URL, so the captured value would be stale.
+                    sendButtonCallback(mCurrentProps ?: popup, btn)
                     mHandler.post { removePopup(true) }
                 }
 
@@ -428,7 +434,7 @@ class PiPupService : Service(), WebServer.Handler {
 
             mCurrentProps = popup
             mShownAt = SystemClock.elapsedRealtime()
-            mPopupsShown++
+            mPopupsShown.incrementAndGet()
 
             if (!popup.tts.isNullOrBlank()) {
                 speak(popup.tts, popup.ttsLanguage)
@@ -453,8 +459,8 @@ class PiPupService : Service(), WebServer.Handler {
             "name" to deviceName(),
             "visible" to (current != null),
             "screenOn" to powerManager.isInteractive,
-            "popupsShown" to mPopupsShown,
-            "watchdogCleanups" to mWatchdogCleanups,
+            "popupsShown" to mPopupsShown.get(),
+            "watchdogCleanups" to mWatchdogCleanups.get(),
             "uptime" to (SystemClock.elapsedRealtime() - mStartedAt) / 1000,
             "device" to mapOf(
                 "model" to Build.MODEL,
@@ -510,16 +516,22 @@ class PiPupService : Service(), WebServer.Handler {
                                 val popup = when {
                                     contentType.startsWith(APPLICATION_JSON) -> {
 
-                                        // try to handle it as json
+                                        // read the body by Content-Length when present, else
+                                        // fall back to draining the stream (chunked transfer /
+                                        // clients that omit the header would otherwise parse as empty)
 
-                                        val contentLength = session.headers["content-length"]?.toInt() ?: 0
-                                        val content = ByteArray(contentLength)
-
-                                        var read = 0
-                                        while (read < contentLength) {
-                                            val res = session.inputStream.read(content, read, contentLength - read)
-                                            if (res < 0) break
-                                            read += res
+                                        val declaredLength = session.headers["content-length"]?.toIntOrNull()
+                                        val content = if (declaredLength != null && declaredLength >= 0) {
+                                            val buf = ByteArray(declaredLength)
+                                            var read = 0
+                                            while (read < declaredLength) {
+                                                val res = session.inputStream.read(buf, read, declaredLength - read)
+                                                if (res < 0) break
+                                                read += res
+                                            }
+                                            buf
+                                        } else {
+                                            session.inputStream.readBytes()
                                         }
 
                                         Json.readValue(content, PopupProps::class.java)

--- a/app/src/main/java/nl/rogro82/pipup/PopupProps.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PopupProps.kt
@@ -53,12 +53,15 @@ data class PopupProps(
         data class Bitmap(val image: android.graphics.Bitmap, val width: Int = DEFAULT_MEDIA_WIDTH): Media()
     }
 
-    enum class Position(index: Int) {
-        TopRight(0),
-        TopLeft(1),
-        BottomRight(2),
-        BottomLeft(3),
-        Center(4)
+    // NB: the multipart parser and the ha-pipup integration both map an integer
+    // position onto this enum by ORDINAL (values()[n]) — the declaration order is
+    // therefore a contract. Do not reorder; append new positions at the end only.
+    enum class Position {
+        TopRight,   // 0
+        TopLeft,    // 1
+        BottomRight, // 2
+        BottomLeft, // 3
+        Center      // 4
     }
 
     companion object {

--- a/readme.md
+++ b/readme.md
@@ -76,6 +76,22 @@ The second command grants the overlay permission, which has no settings UI on An
 _After installation or updating, open the application once (or reboot the TV) to make sure the
 background service is running._
 
+## Security
+
+PiPup runs an embedded webserver (NanoHTTPD) on port **7979** with **no authentication**,
+and a popup's `web` media is rendered in a WebView with JavaScript and DOM storage enabled.
+That means **any device on the same network can display arbitrary content — including
+JavaScript — on the TV.** This is by design (camera/stream pages need it), but it makes the
+trust boundary the network itself.
+
+- Run PiPup TVs on a **trusted network segment** (not a guest/IoT VLAN that untrusted devices share).
+- Traffic is plain HTTP (`usesCleartextTraffic`), so treat everything sent to the popup — URLs,
+  TTS text, button callbacks — as visible on the LAN.
+- Button presses POST to the `callback` URL supplied with the popup. If you drive security-sensitive
+  automations from button events (e.g. unlocking a door), have the caller include an unguessable,
+  single-use token in that callback URL and verify it on receipt — the
+  [ha-pipup integration](https://github.com/mhoogenbosch/ha-pipup) does this automatically.
+
 ## Integrating
 
 PiPup runs an embedded webserver (NanoHTTPD) on port **7979**.


### PR DESCRIPTION
Code-review follow-up (app side).

- **Thread-safety**: `/state` reads `mCurrentProps`/`mShownAt`/`mPopupsShown`/`mWatchdogCleanups` on the NanoHTTPD worker thread while the main thread writes them — now `@Volatile` / `AtomicLong`. These fields feed the HA sensors, so a torn read is a real defect.
- **Callback closure**: a button press posted to the capturing `popup`'s callback, which is stale after an update-in-place; now reads `mCurrentProps`.
- **Body read**: JSON `/notify` parsed as empty when `Content-Length` was missing (chunked); falls back to draining the stream.
- **Position enum**: removed the misleading unused `index` arg; documented the ordinal contract with the multipart parser + integration.
- **README Security section**: the server is unauthenticated and the WebView runs JS — documents the network trust boundary and token-guarded callbacks.

Debug build passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)