### PR TITLE
ci: skip the APK build for documentation-only PRs

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,28 @@
+name: Build APK (docs)
+
+# Branch protection requires the "build" status check on master. A required check
+# that never runs leaves a pull request blocked forever, so documentation-only
+# changes — which build.yml skips via paths-ignore — get the same check reported
+# by this no-op job instead of building an APK.
+#
+# Keep the path list here in sync with the paths-ignore list in build.yml.
+
+on:
+  pull_request:
+    paths:
+      - '**.md'
+      - 'graphics/**'
+      - '.idea/**'
+      - 'LICENSE'
+      - '.gitignore'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: No code changed
+        run: echo "Documentation-only change — no APK build needed."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,22 @@ on:
     branches: [master]
     tags: ['v*']
   pull_request:
+    # Documentation-only changes are covered by build-docs.yml, which reports the
+    # same required "build" check without compiling an APK — a readme edit should
+    # not have to wait for Gradle (and for a free runner) to become mergeable.
+    paths-ignore:
+      - '**.md'
+      - 'graphics/**'
+      - '.idea/**'
+      - 'LICENSE'
+      - '.gitignore'
   workflow_dispatch:
+
+concurrency:
+  # Never let two runs for the same ref fight over the "build" status check; the
+  # cancelled one reports a failure and blocks the pull request.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
## English

A readme-only pull request (#2) had to satisfy the required `build` status check, which meant a full
Gradle/APK build. With free runners queueing for 15+ minutes that job was cancelled before executing
a single step, reported a failure, and left the PR unmergeable — for a change that cannot possibly
break the build.

- Documentation paths (`**.md`, `graphics/**`, `.idea/**`, `LICENSE`, `.gitignore`) are excluded from
  `build.yml`.
- A new `build-docs.yml` reports the same `build` check for exactly those paths. This is deliberate:
  a required status check that never runs blocks a pull request forever, so `paths-ignore` on its own
  would be a trap.
- A `concurrency` group prevents two runs for the same ref from fighting over the `build` check (the
  cancelled one reports a failure).

Tags and pushes to `master` are unaffected, so releases still build and publish the APK.

## Nederlands

Een readme-only PR (#2) moest langs de verplichte `build`-check, en dus langs een volledige
Gradle/APK-build. Met gratis runners die 15+ minuten in de wachtrij staan werd die job gecanceld vóór
er één stap liep, meldde een failure, en bleef de PR onmergebaar — voor een wijziging die de build
onmogelijk kan breken.

- Documentatiepaden (`**.md`, `graphics/**`, `.idea/**`, `LICENSE`, `.gitignore`) zijn uitgesloten in
  `build.yml`.
- Een nieuwe `build-docs.yml` levert dezelfde `build`-check voor precies die paden. Dat is bewust: een
  verplichte status check die nooit draait blokkeert een PR voor altijd, dus alleen `paths-ignore` zou
  een valkuil zijn.
- Een `concurrency`-groep voorkomt dat twee runs voor dezelfde ref om de `build`-check vechten (de
  gecancelde meldt een failure).

Tags en pushes naar `master` blijven ongewijzigd, dus releases bouwen en publiceren de APK nog steeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
