### PR TITLE
v0.7.0: custom border styling, screen on/off, installers + permission reporting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,4 +70,9 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
-          files: PiPup.apk
+          # the installers ship with the APK: they grant the app-ops the app cannot
+          # grant itself, so a release is usable without cloning the repo
+          files: |
+            PiPup.apk
+            install.sh
+            install.ps1

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "nl.rogro82.pipup"
         minSdkVersion 24
         targetSdkVersion 34
-        versionCode 21
-        versionName "0.6.2"
+        versionCode 22
+        versionName "0.7.0"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,9 @@
          (self-update only, and the signature must match — see UpdateManager). -->
     <uses-permission android:name="android.permission.UPDATE_PACKAGES_WITHOUT_USER_ACTION" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <!-- Screen on (POST /power?state=on): the wake lock is a best-effort second
+         attempt next to WakeActivity's setTurnScreenOn. -->
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <uses-feature
             android:name="android.hardware.touchscreen"
@@ -56,6 +59,44 @@
                     android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
                     android:value="Displays HTTP-triggered overlay notifications on the TV"/>
         </service>
+
+        <!-- Screen off (POST /power?state=off). Inactive until someone grants it:
+             `adb shell dpm set-active-admin nl.rogro82.pipup/.AdminReceiver` -->
+        <receiver
+                android:name=".AdminReceiver"
+                android:exported="true"
+                android:permission="android.permission.BIND_DEVICE_ADMIN">
+            <meta-data
+                    android:name="android.app.device_admin"
+                    android:resource="@xml/device_admin"/>
+            <intent-filter>
+                <action android:name="android.app.action.DEVICE_ADMIN_ENABLED"/>
+            </intent-filter>
+        </receiver>
+
+        <!-- Fallback route for screen off, for devices where lockNow() does not reach
+             standby. Observes nothing (see accessibility_service.xml) and stays dormant
+             until enabled in the accessibility settings. -->
+        <service
+                android:name=".PiPupAccessibilityService"
+                android:exported="true"
+                android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE">
+            <intent-filter>
+                <action android:name="android.accessibilityservice.AccessibilityService"/>
+            </intent-filter>
+            <meta-data
+                    android:name="android.accessibilityservice"
+                    android:resource="@xml/accessibility_service"/>
+        </service>
+
+        <!-- Invisible, finishes itself; only exists to turn the screen on. -->
+        <activity
+                android:name=".WakeActivity"
+                android:exported="false"
+                android:excludeFromRecents="true"
+                android:noHistory="true"
+                android:taskAffinity=""
+                android:theme="@android:style/Theme.Translucent.NoTitleBar"/>
 
         <activity
                 android:name=".MainActivity"

--- a/app/src/main/java/nl/rogro82/pipup/AdminReceiver.kt
+++ b/app/src/main/java/nl/rogro82/pipup/AdminReceiver.kt
@@ -1,0 +1,23 @@
+package nl.rogro82.pipup
+
+import android.app.admin.DeviceAdminReceiver
+import android.content.ComponentName
+import android.content.Context
+
+/// Device admin with a single purpose: `lockNow()`, which puts an Android TV into
+/// standby. Nothing else about the device is managed - the policy file only asks
+/// for `force-lock`.
+///
+/// Activating an admin normally needs an on-screen confirmation, which is awkward
+/// with a remote; grant it once over adb instead (install.sh does this for you):
+///
+///     adb shell dpm set-active-admin nl.rogro82.pipup/.AdminReceiver
+///
+/// Until then /state reports `power.canSleep: false` and the app never pretends it
+/// can turn the screen off.
+class AdminReceiver : DeviceAdminReceiver() {
+    companion object {
+        fun component(context: Context): ComponentName =
+            ComponentName(context.applicationContext, AdminReceiver::class.java)
+    }
+}

--- a/app/src/main/java/nl/rogro82/pipup/MainActivity.kt
+++ b/app/src/main/java/nl/rogro82/pipup/MainActivity.kt
@@ -33,6 +33,7 @@ class MainActivity : Activity() {
     private val mRefresh = object : Runnable {
         override fun run() {
             refreshStatus()
+            refreshWarning()
             mHandler.postDelayed(this, REFRESH_INTERVAL_MS)
         }
     }
@@ -81,6 +82,15 @@ class MainActivity : Activity() {
     override fun onPause() {
         super.onPause()
         mHandler.removeCallbacks(mRefresh)
+    }
+
+    /// The one failure mode that looks like success from the outside: without the overlay
+    /// permission every /notify is answered with 200 and nothing appears on screen. Say so
+    /// here, on the only screen someone with a remote can reach, with the command to fix it.
+    /// Re-checked on every refresh so the warning disappears as soon as it is granted.
+    private fun refreshWarning() {
+        findViewById<TextView>(R.id.textViewWarning)?.visibility =
+            if (Permissions.overlay(this)) View.GONE else View.VISIBLE
     }
 
     /// Live status block below the server address. Fetched from the service's own

--- a/app/src/main/java/nl/rogro82/pipup/Permissions.kt
+++ b/app/src/main/java/nl/rogro82/pipup/Permissions.kt
@@ -1,0 +1,68 @@
+package nl.rogro82.pipup
+
+import android.app.AppOpsManager
+import android.content.Context
+import android.os.Build
+import android.provider.Settings
+import android.util.Log
+
+/// What PiPup was actually granted on this device.
+///
+/// An app cannot grant itself any of these: `appops` is shell/system territory, which is
+/// exactly why the readme hands out adb commands. What it *can* do is report the truth, so
+/// the status screen and /state show a missing overlay permission instead of leaving you
+/// with an app that answers every request happily and never draws anything.
+object Permissions {
+
+    const val LOG_TAG = "Permissions"
+
+    /// SYSTEM_ALERT_WINDOW - without it popups are accepted but never appear.
+    fun overlay(context: Context): Boolean = try {
+        Settings.canDrawOverlays(context)
+    } catch (ex: Throwable) {
+        Log.e(LOG_TAG, "Cannot query overlay permission: ${ex.message}")
+        false
+    }
+
+    /// REQUEST_INSTALL_PACKAGES - needed for the self-update to install its download.
+    fun installPackages(context: Context): Boolean = try {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            context.packageManager.canRequestPackageInstalls()
+        } else true
+    } catch (ex: Throwable) {
+        Log.e(LOG_TAG, "Cannot query install permission: ${ex.message}")
+        false
+    }
+
+    /// TCL's vendor app-op that decides whether Android may restart a killed service.
+    /// Returns null on devices that do not have the op at all (Fire TV, Nokia, Xiaomi, ...),
+    /// which is a different thing from "not granted" and must not be reported as a problem.
+    fun autoStart(context: Context): Boolean? = try {
+        val ops = context.getSystemService(Context.APP_OPS_SERVICE) as AppOpsManager
+        val mode = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            ops.unsafeCheckOpNoThrow(OP_AUTO_START, android.os.Process.myUid(), context.packageName)
+        } else {
+            @Suppress("DEPRECATION")
+            ops.checkOpNoThrow(OP_AUTO_START, android.os.Process.myUid(), context.packageName)
+        }
+        mode == AppOpsManager.MODE_ALLOWED
+    } catch (_: Throwable) {
+        // IllegalArgumentException("Unknown operation string") on every non-TCL device
+        null
+    }
+
+    /// Everything this device needs for popups to work. Vendor-specific and
+    /// power-related grants are reported separately: they are optional.
+    fun complete(context: Context): Boolean = overlay(context)
+
+    fun asMap(context: Context): Map<String, Any?> = mapOf(
+        "overlay" to overlay(context),
+        "installPackages" to installPackages(context),
+        "autoStart" to autoStart(context),
+        "deviceAdmin" to PowerController.deviceAdminActive(context),
+        "accessibility" to PiPupAccessibilityService.enabledInSettings(context),
+        "complete" to complete(context)
+    )
+
+    private const val OP_AUTO_START = "android:auto_start"
+}

--- a/app/src/main/java/nl/rogro82/pipup/PiPupAccessibilityService.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PiPupAccessibilityService.kt
@@ -1,0 +1,72 @@
+package nl.rogro82.pipup
+
+import android.accessibilityservice.AccessibilityService
+import android.content.Context
+import android.os.Build
+import android.provider.Settings
+import android.util.Log
+import android.view.accessibility.AccessibilityEvent
+
+/// Fallback route for turning the screen off, for devices where the device admin
+/// `lockNow()` does not reach standby. An enabled accessibility service may call
+/// `GLOBAL_ACTION_LOCK_SCREEN` (Android 9 / API 28 and up).
+///
+/// It observes nothing: no event types are declared in accessibility_service.xml, so
+/// the service never receives UI content - it exists purely for that one action.
+/// Enable it once over adb (install.sh --accessibility does this):
+///
+///     adb shell settings put secure enabled_accessibility_services \
+///         nl.rogro82.pipup/nl.rogro82.pipup.PiPupAccessibilityService
+///     adb shell settings put secure accessibility_enabled 1
+class PiPupAccessibilityService : AccessibilityService() {
+
+    override fun onServiceConnected() {
+        super.onServiceConnected()
+        instance = this
+        Log.d(LOG_TAG, "Accessibility service connected")
+    }
+
+    override fun onUnbind(intent: android.content.Intent?): Boolean {
+        instance = null
+        return super.onUnbind(intent)
+    }
+
+    override fun onAccessibilityEvent(event: AccessibilityEvent?) {}
+
+    override fun onInterrupt() {}
+
+    companion object {
+        const val LOG_TAG = "PiPupAccessibility"
+
+        @Volatile
+        private var instance: PiPupAccessibilityService? = null
+
+        /// Whether the service is connected *and* the platform has the lock action.
+        fun available(): Boolean =
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && instance != null
+
+        /// Whether the user (or adb) enabled us in the accessibility settings. Read from
+        /// settings rather than from `instance`, so a service that is enabled but not yet
+        /// bound still reports as configured.
+        fun enabledInSettings(context: Context): Boolean = try {
+            val enabled = Settings.Secure.getString(
+                context.contentResolver, Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES
+            ) ?: ""
+            enabled.split(':').any { it.substringBefore('/') == context.packageName }
+        } catch (ex: Throwable) {
+            Log.e(LOG_TAG, "Cannot read accessibility settings: ${ex.message}")
+            false
+        }
+
+        fun lockScreen(): Boolean {
+            val service = instance ?: return false
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) return false
+            return try {
+                service.performGlobalAction(GLOBAL_ACTION_LOCK_SCREEN)
+            } catch (ex: Throwable) {
+                Log.e(LOG_TAG, "GLOBAL_ACTION_LOCK_SCREEN failed: ${ex.message}")
+                false
+            }
+        }
+    }
+}

--- a/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
@@ -628,6 +628,12 @@ class PiPupService : Service(), WebServer.Handler {
                 "elapsed" to ((SystemClock.elapsedRealtime() - mShownAt) / 1000)
             )
         }
+        state["power"] = mapOf(
+            "canWake" to true,
+            "canSleep" to PowerController.canSleep(this),
+            "sleepMethod" to PowerController.sleepMethod(this)
+        )
+        state["permissions"] = Permissions.asMap(this)
         state["update"] = mapOf(
             "available" to UpdateManager.updateAvailable,
             "latest" to UpdateManager.latestVersion,
@@ -654,6 +660,42 @@ class PiPupService : Service(), WebServer.Handler {
             NanoHTTPD.Response.Status.OK,
             APPLICATION_JSON,
             Json.writeValueAsString(state)
+        )
+    }
+
+    /// POST /power?state=on|off|toggle - screen on/off for this TV.
+    ///
+    /// Runs straight on the web-server thread: waking (startActivity/wake lock) and
+    /// sleeping (lockNow/global action) are binder calls that touch no views, so the
+    /// caller gets the real result instead of a fire-and-forget "accepted".
+    ///
+    /// 501 (not 400) when the device has no way to turn the screen off - that tells a
+    /// controller "this device cannot", as opposed to "your request was malformed".
+    private fun powerResponse(session: NanoHTTPD.IHTTPSession): NanoHTTPD.Response {
+        val requested = session.parameters["state"]?.firstOrNull()?.lowercase()
+        val target = when (requested) {
+            "on", "wake", "true", "1" -> true
+            "off", "sleep", "false", "0" -> false
+            "toggle" -> !PowerController.screenOn(this)
+            else -> return InvalidRequest("state must be on, off or toggle")
+        }
+
+        val method = if (target) "activity" else PowerController.sleepMethod(this)
+        val ok = if (target) PowerController.wake(this) else PowerController.sleep(this)
+
+        Log.d(LOG_TAG, "Power ${if (target) "on" else "off"} via ${method ?: "-"}: ok=$ok")
+
+        val body = Json.writeValueAsString(mapOf(
+            "state" to if (target) "on" else "off",
+            "ok" to ok,
+            "method" to method,
+            // the wake activity is still starting up, so this can lag one poll behind
+            "screenOn" to PowerController.screenOn(this)
+        ))
+        return newFixedLengthResponse(
+            if (ok) NanoHTTPD.Response.Status.OK else NanoHTTPD.Response.Status.NOT_IMPLEMENTED,
+            APPLICATION_JSON,
+            body
         )
     }
 
@@ -698,6 +740,7 @@ class PiPupService : Service(), WebServer.Handler {
                             }.start()
                             OK("update started")
                         }
+                        "/power" -> powerResponse(session)
                         "/cancel" -> {
                             // optional ?id=<popup id>: only cancel when it matches the visible popup
                             val id = session.parameters["id"]?.firstOrNull()
@@ -798,7 +841,13 @@ class PiPupService : Service(), WebServer.Handler {
                                             messageColor = messageColor,
                                             media = media,
                                             tts = params["tts"],
-                                            ttsLanguage = params["ttsLanguage"]
+                                            ttsLanguage = params["ttsLanguage"],
+                                            // styling also applies to uploaded snapshots
+                                            urgency = params["urgency"],
+                                            borderColor = params["borderColor"],
+                                            borderWidth = params["borderWidth"]?.toIntOrNull(),
+                                            cornerRadius = params["cornerRadius"]?.toFloatOrNull(),
+                                            showProgress = params["showProgress"]?.toBoolean() ?: false
                                         )
                                     }
                                     else -> throw Exception("invalid content-type")

--- a/app/src/main/java/nl/rogro82/pipup/PopupProps.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PopupProps.kt
@@ -20,6 +20,12 @@ data class PopupProps(
     val tts: String? = null,              // optional text spoken on the device when the popup is (re)shown
     val ttsLanguage: String? = null,      // optional BCP-47 tag (e.g. "nl-NL"); device default when omitted
     val urgency: String? = null,          // info | warning | critical: colored border preset
+    // Explicit border styling; each field overrides the urgency preset on its own, so
+    // `urgency` keeps working as a shorthand. Sizes are in pixels, like every other
+    // dimension in this API (media width, padding) - see the px/dp TODO in PopupView.
+    val borderColor: String? = null,      // #RRGGBB or #AARRGGBB
+    val borderWidth: Int? = null,         // 0 = no border, also to switch an urgency border off
+    val cornerRadius: Float? = null,      // 0 = square corners
     val showProgress: Boolean = false,    // countdown bar for popups with a finite duration
     val buttons: List<Button> = emptyList(), // DPAD-focusable buttons; pressing one POSTs to callback and dismisses
     val callback: String? = null          // URL that receives {"popup","button","device"} on a button press
@@ -72,7 +78,17 @@ data class PopupProps(
         const val DEFAULT_MESSAGE_SIZE = 12f
         const val DEFAULT_MESSAGE_COLOR = "#ffffff"
         const val DEFAULT_MEDIA_WIDTH = 480
+        const val DEFAULT_BORDER_WIDTH = 4          // a borderColor without a borderWidth
+        const val DEFAULT_BORDER_COLOR = "#ffffff"  // a borderWidth without a borderColor
+        const val DEFAULT_CORNER_RADIUS = 8f        // whenever a border is drawn
 
         val DEFAULT_POSITION: Position = Position.TopRight
+
+        /// urgency shorthand -> border width (px) and color
+        val URGENCY_PRESETS: Map<String, Pair<Int, String>> = mapOf(
+            "info" to (4 to "#2196F3"),
+            "warning" to (6 to "#FF9800"),
+            "critical" to (8 to "#F44336")
+        )
     }
 }

--- a/app/src/main/java/nl/rogro82/pipup/PopupView.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PopupView.kt
@@ -55,7 +55,7 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
         } else {
             title.text = popup.title
             title.textSize = popup.titleSize
-            title.setTextColor(Color.parseColor(popup.titleColor))
+            title.setTextColor(parseColorOrDefault(popup.titleColor, PopupProps.DEFAULT_TITLE_COLOR))
         }
 
         if(popup.message.isNullOrEmpty()) {
@@ -63,21 +63,27 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
         } else {
             message.text = popup.message
             message.textSize = popup.messageSize
-            message.setTextColor(Color.parseColor(popup.messageColor))
+            message.setTextColor(parseColorOrDefault(popup.messageColor, PopupProps.DEFAULT_MESSAGE_COLOR))
         }
 
-        // background with optional urgency border preset
+        // background with an optional border: `urgency` is a shorthand for a
+        // (width, color) pair, and borderColor/borderWidth/cornerRadius each
+        // override their part of it independently.
         background = GradientDrawable().apply {
-            try {
-                setColor(Color.parseColor(popup.backgroundColor))
-            } catch (_: Throwable) {
-                setColor(Color.parseColor(PopupProps.DEFAULT_BACKGROUND_COLOR))
+            setColor(parseColorOrDefault(popup.backgroundColor, PopupProps.DEFAULT_BACKGROUND_COLOR))
+
+            val preset = PopupProps.URGENCY_PRESETS[popup.urgency?.lowercase()]
+            val width = popup.borderWidth ?: preset?.first
+                ?: popup.borderColor?.let { PopupProps.DEFAULT_BORDER_WIDTH }
+            val color = popup.borderColor ?: preset?.second
+                ?: PopupProps.DEFAULT_BORDER_COLOR
+
+            if (width != null && width > 0) {
+                setStroke(width, parseColorOrDefault(color, PopupProps.DEFAULT_BORDER_COLOR))
             }
-            when (popup.urgency?.lowercase()) {
-                "info" -> { setStroke(4, Color.parseColor("#2196F3")); cornerRadius = 8f }
-                "warning" -> { setStroke(6, Color.parseColor("#FF9800")); cornerRadius = 8f }
-                "critical" -> { setStroke(8, Color.parseColor("#F44336")); cornerRadius = 8f }
-            }
+            // rounded corners keep working without a border, and an explicit 0 squares them off
+            cornerRadius = popup.cornerRadius
+                ?: if (width != null && width > 0) PopupProps.DEFAULT_CORNER_RADIUS else 0f
         }
 
         // DPAD-focusable buttons (the service makes the overlay window focusable)
@@ -291,6 +297,15 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
 
     companion object {
         const val LOG_TAG = "PopupView"
+
+        /// A malformed color must never take the whole popup down: an unparseable
+        /// value falls back instead of throwing out of create().
+        fun parseColorOrDefault(value: String?, fallback: String): Int = try {
+            Color.parseColor(value)
+        } catch (_: Throwable) {
+            Log.w(LOG_TAG, "Unparseable color '$value', using $fallback")
+            Color.parseColor(fallback)
+        }
 
         const val MUTE_JS = """
             (function() {

--- a/app/src/main/java/nl/rogro82/pipup/PowerController.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PowerController.kt
@@ -1,0 +1,109 @@
+package nl.rogro82.pipup
+
+import android.app.admin.DevicePolicyManager
+import android.content.Context
+import android.content.Intent
+import android.os.PowerManager
+import android.util.Log
+
+/// Screen on/off for the TV this app runs on, as far as a sideloaded app can reach:
+///
+/// * **on** - launch [WakeActivity]; that is the supported wake path, and on HDMI-CEC
+///   setups it brings the TV set along.
+/// * **off** - `DevicePolicyManager.lockNow()` via [AdminReceiver], or
+///   [PiPupAccessibilityService]'s `GLOBAL_ACTION_LOCK_SCREEN` when no admin is active.
+///   Both need a one-time grant over adb (see install.sh), so this is the one capability
+///   that can genuinely be unavailable on a device.
+///
+/// Nothing here pretends: [sleepMethod] returns null when neither route is granted and
+/// /state publishes that, so a controller (e.g. the Home Assistant integration) can hide
+/// the off switch instead of offering a button that quietly does nothing.
+object PowerController {
+
+    const val LOG_TAG = "PowerController"
+
+    const val METHOD_DEVICE_ADMIN = "device_admin"
+    const val METHOD_ACCESSIBILITY = "accessibility"
+
+    /// self-releasing: a leaked wake lock would keep the TV awake forever
+    private const val WAKE_LOCK_TIMEOUT_MS = 3_000L
+
+    fun screenOn(context: Context): Boolean =
+        (context.getSystemService(Context.POWER_SERVICE) as PowerManager).isInteractive
+
+    fun deviceAdminActive(context: Context): Boolean = try {
+        val dpm = context.getSystemService(Context.DEVICE_POLICY_SERVICE) as DevicePolicyManager
+        dpm.isAdminActive(AdminReceiver.component(context))
+    } catch (ex: Throwable) {
+        Log.e(LOG_TAG, "Cannot query device admin: ${ex.message}")
+        false
+    }
+
+    /// Which route would be used for "off" right now, or null when none is granted.
+    fun sleepMethod(context: Context): String? = when {
+        deviceAdminActive(context) -> METHOD_DEVICE_ADMIN
+        PiPupAccessibilityService.available() -> METHOD_ACCESSIBILITY
+        else -> null
+    }
+
+    fun canSleep(context: Context): Boolean = sleepMethod(context) != null
+
+    /// Turn the screen on. Returns false only when the platform refused both attempts.
+    fun wake(context: Context): Boolean {
+        var ok = false
+
+        // Best-effort, and deliberately first: on devices where it still works the screen
+        // is already coming up by the time the activity is launched.
+        try {
+            @Suppress("DEPRECATION")
+            val lock = (context.getSystemService(Context.POWER_SERVICE) as PowerManager)
+                .newWakeLock(
+                    PowerManager.SCREEN_BRIGHT_WAKE_LOCK or
+                            PowerManager.ACQUIRE_CAUSES_WAKEUP or
+                            PowerManager.ON_AFTER_RELEASE,
+                    "PiPup:wake"
+                )
+            lock.acquire(WAKE_LOCK_TIMEOUT_MS)
+            ok = true
+        } catch (ex: Throwable) {
+            Log.e(LOG_TAG, "Wake lock failed: ${ex.message}")
+        }
+
+        try {
+            context.startActivity(
+                Intent(context, WakeActivity::class.java).addFlags(
+                    Intent.FLAG_ACTIVITY_NEW_TASK or
+                            Intent.FLAG_ACTIVITY_NO_ANIMATION or
+                            Intent.FLAG_ACTIVITY_NO_HISTORY
+                )
+            )
+            ok = true
+        } catch (ex: Throwable) {
+            Log.e(LOG_TAG, "WakeActivity launch failed: ${ex.message}")
+        }
+
+        return ok
+    }
+
+    /// Turn the screen off (standby). Returns false when no route is granted, or when the
+    /// granted one refused - the caller reports that instead of claiming success.
+    fun sleep(context: Context): Boolean {
+        if (deviceAdminActive(context)) {
+            try {
+                val dpm =
+                    context.getSystemService(Context.DEVICE_POLICY_SERVICE) as DevicePolicyManager
+                dpm.lockNow()
+                return true
+            } catch (ex: Throwable) {
+                // e.g. SecurityException when force-lock was revoked behind our back:
+                // fall through to the accessibility route rather than giving up
+                Log.e(LOG_TAG, "lockNow failed: ${ex.message}")
+            }
+        }
+        if (PiPupAccessibilityService.lockScreen()) {
+            return true
+        }
+        Log.w(LOG_TAG, "No way to turn the screen off: grant device admin or accessibility")
+        return false
+    }
+}

--- a/app/src/main/java/nl/rogro82/pipup/WakeActivity.kt
+++ b/app/src/main/java/nl/rogro82/pipup/WakeActivity.kt
@@ -1,0 +1,45 @@
+package nl.rogro82.pipup
+
+import android.app.Activity
+import android.os.Build
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.view.WindowManager
+
+/// Invisible activity whose only job is to turn the screen on. Launching an activity
+/// with `setTurnScreenOn(true)` is the supported way to wake a device (the wake lock
+/// route is deprecated and unreliable from Android 9 onwards), and on HDMI-CEC setups
+/// waking the box also switches the TV to its input.
+///
+/// It is translucent, `noHistory` and finishes itself again, so nothing lands in
+/// recents and whatever was in the foreground comes straight back.
+class WakeActivity : Activity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+            setShowWhenLocked(true)
+            setTurnScreenOn(true)
+        } else {
+            @Suppress("DEPRECATION")
+            window.addFlags(
+                WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED or
+                        WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON or
+                        WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD
+            )
+        }
+        // hold the screen until we finish, so the device cannot doze straight back off
+        window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+
+        Handler(Looper.getMainLooper()).postDelayed({
+            if (!isFinishing) finish()
+        }, FINISH_DELAY_MS)
+    }
+
+    companion object {
+        /// Long enough for the panel (and a CEC-linked TV) to actually come up.
+        const val FINISH_DELAY_MS = 1500L
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -52,4 +52,20 @@
             app:layout_constraintTop_toBottomOf="@+id/textViewServerAddress"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"/>
+    <TextView
+            android:text="@string/warning_no_overlay"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:id="@+id/textViewWarning"
+            android:gravity="center_horizontal"
+            android:textColor="@color/warning"
+            android:textSize="13sp"
+            android:lineSpacingExtra="2dp"
+            android:visibility="gone"
+            android:layout_marginTop="16dp"
+            android:layout_marginStart="24dp"
+            android:layout_marginEnd="24dp"
+            app:layout_constraintTop_toBottomOf="@+id/textViewStatus"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"/>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -8,4 +8,6 @@
     <string name="update_available_title">PiPup %1$s is beschikbaar</string>
     <string name="update_available_message">Druk op OK om de update nu te installeren.</string>
     <string name="update_install">Installeren</string>
+    <string name="accessibility_service_description">Hiermee kan PiPup het scherm op verzoek uitzetten. Alleen nodig op toestellen waar de apparaatbeheerder dat niet kan; PiPup leest niets van het scherm.</string>
+    <string name="warning_no_overlay">Geen overlay-permissie — popups worden aangenomen maar blijven onzichtbaar. Ken die eenmalig toe via adb:\nadb shell appops set nl.rogro82.pipup SYSTEM_ALERT_WINDOW allow</string>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,2 +1,4 @@
 <resources>
+    <!-- status screen: missing permission warning -->
+    <color name="warning">#FFB300</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,4 +12,6 @@
     <string name="update_available_title">PiPup %1$s is available</string>
     <string name="update_available_message">Press OK to install the update now.</string>
     <string name="update_install">Install</string>
+    <string name="accessibility_service_description">Lets PiPup turn the screen off on request. Only needed on devices where the device admin cannot; PiPup reads nothing from the screen.</string>
+    <string name="warning_no_overlay">No overlay permission — popups are accepted but stay invisible. Grant it once over adb:\nadb shell appops set nl.rogro82.pipup SYSTEM_ALERT_WINDOW allow</string>
 </resources>

--- a/app/src/main/res/xml/accessibility_service.xml
+++ b/app/src/main/res/xml/accessibility_service.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Deliberately observes nothing: no accessibilityEventTypes and no
+     canRetrieveWindowContent, so the service never sees any UI content. It is
+     only bound so PiPup can call GLOBAL_ACTION_LOCK_SCREEN (screen off). -->
+<accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
+        android:accessibilityFeedbackType="feedbackGeneric"
+        android:description="@string/accessibility_service_description"
+        android:notificationTimeout="0"/>

--- a/app/src/main/res/xml/device_admin.xml
+++ b/app/src/main/res/xml/device_admin.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Only force-lock: PiPup uses the admin exclusively for lockNow() (screen off).
+     Deliberately no password, camera or wipe policies - those are also the ones
+     Android deprecated for legacy device admins from Android 9 onwards. -->
+<device-admin xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-policies>
+        <force-lock/>
+    </uses-policies>
+</device-admin>

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,188 @@
+<#
+.SYNOPSIS
+    PiPup installer for Windows: sideloads the APK on one or more Android TVs and grants
+    the app-ops an app cannot grant itself.
+
+.EXAMPLE
+    .\install.ps1 192.168.1.10 192.168.1.11
+.EXAMPLE
+    .\install.ps1 -Power -Apk PiPup.apk 192.168.1.10
+
+.NOTES
+    SYSTEM_ALERT_WINDOW and REQUEST_INSTALL_PACKAGES are app-ops: only adb/shell or the
+    system can set them, and every reinstall resets them. Hence this script.
+    Requires adb on PATH and adb debugging enabled on the TV.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(ValueFromRemainingArguments = $true, Mandatory = $true)]
+    [string[]]$Devices,
+
+    # APK to install; downloads the latest release when omitted
+    [string]$Apk,
+
+    # also grant device admin, so POST /power?state=off works
+    [switch]$Power,
+
+    # also enable the accessibility fallback for screen off
+    [switch]$Accessibility,
+
+    # uninstall first on a signature clash (WARNING: wipes the stable device id)
+    [switch]$ForceUninstall
+)
+
+$ErrorActionPreference = 'Continue'
+
+$Package = 'nl.rogro82.pipup'
+$AdminComponent = "$Package/.AdminReceiver"
+$AccessibilityComponent = "$Package/$Package.PiPupAccessibilityService"
+$Repo = 'mhoogenbosch/PiPup'
+$Port = 7979
+
+function Write-Ok    { param($m) Write-Host "  [ok] $m" -ForegroundColor Green }
+function Write-Warn  { param($m) Write-Host "  [!]  $m" -ForegroundColor Yellow }
+function Write-Fail  { param($m) Write-Host "  [x]  $m" -ForegroundColor Red }
+
+if (-not (Get-Command adb -ErrorAction SilentlyContinue)) {
+    Write-Fail 'adb not found on PATH'
+    exit 1
+}
+
+# ---------------------------------------------------------------- APK
+
+if (-not $Apk) {
+    if (Test-Path 'PiPup.apk') {
+        $Apk = 'PiPup.apk'
+        Write-Host 'Using .\PiPup.apk'
+    } else {
+        Write-Host "Downloading the latest release from github.com/$Repo ..."
+        try {
+            $release = Invoke-RestMethod "https://api.github.com/repos/$Repo/releases/latest" `
+                -Headers @{ 'User-Agent' = 'pipup-install' }
+            $asset = $release.assets | Where-Object { $_.name -like '*.apk' } | Select-Object -First 1
+            if (-not $asset) { throw 'no APK asset in the latest release' }
+            Invoke-WebRequest $asset.browser_download_url -OutFile 'PiPup.apk'
+            $Apk = 'PiPup.apk'
+            Write-Ok "downloaded $($asset.name)"
+        } catch {
+            Write-Fail "download failed: $_"
+            exit 1
+        }
+    }
+}
+if (-not (Test-Path $Apk)) {
+    Write-Fail "APK not found: $Apk"
+    exit 1
+}
+
+# ---------------------------------------------------------------- per device
+
+$failed = 0
+
+foreach ($device in $Devices) {
+    if ($device -match ':') {
+        $target = $device
+        $tvHost = $device.Split(':')[0]
+    } else {
+        $target = "${device}:5555"
+        $tvHost = $device
+    }
+
+    Write-Host ''
+    Write-Host "=== $target ==="
+
+    $connect = (adb connect $target 2>&1) -join ' '
+    if ($connect -notmatch 'connected to') {
+        Write-Fail 'cannot connect (adb debugging on? authorised on the TV?)'
+        $failed++
+        continue
+    }
+    adb -s $target wait-for-device | Out-Null
+
+    $out = (adb -s $target install -r $Apk 2>&1) -join ' '
+    if ($out -match 'INSTALL_FAILED_UPDATE_INCOMPATIBLE|signatures do not match') {
+        if ($ForceUninstall) {
+            Write-Warn 'different signature: uninstalling first (device id is lost)'
+            adb -s $target uninstall $Package | Out-Null
+            $out = (adb -s $target install -r $Apk 2>&1) -join ' '
+        } else {
+            Write-Fail "another build of $Package is installed (different signature)."
+            Write-Fail "re-run with -ForceUninstall, or: adb -s $target uninstall $Package"
+            $failed++
+            continue
+        }
+    }
+    if ($out -notmatch 'Success') {
+        Write-Fail "install failed: $out"
+        $failed++
+        continue
+    }
+    Write-Ok "installed $(Split-Path $Apk -Leaf)"
+
+    # The two app-ops that a reinstall resets and the app cannot set itself.
+    adb -s $target shell "appops set $Package SYSTEM_ALERT_WINDOW allow" | Out-Null
+    Write-Ok 'overlay permission granted'
+    adb -s $target shell "appops set $Package REQUEST_INSTALL_PACKAGES allow" | Out-Null
+    Write-Ok 'self-update permission granted'
+
+    # TCL only; every other brand answers "Unknown operation string", which is fine.
+    $autostart = (adb -s $target shell "cmd appops set $Package android:auto_start allow" 2>&1) -join ' '
+    if ($autostart -match 'Unknown operation string') {
+        Write-Host '  .  no vendor auto-start op on this device (normal outside TCL)'
+    } else {
+        Write-Ok 'auto-start op granted (TCL)'
+    }
+
+    if ($Power) {
+        $admin = (adb -s $target shell "dpm set-active-admin $AdminComponent" 2>&1) -join ' '
+        if ($admin -match 'Success|now an active admin') {
+            Write-Ok 'device admin active (screen off available)'
+        } else {
+            Write-Warn "device admin refused: $admin"
+        }
+    }
+
+    if ($Accessibility) {
+        $current = ((adb -s $target shell 'settings get secure enabled_accessibility_services' 2>$null) -join '').Trim()
+        if ($current -like "*$Package*") {
+            Write-Ok 'accessibility service already enabled'
+        } else {
+            $merged = if ($current -and $current -ne 'null') { "${current}:$AccessibilityComponent" } else { $AccessibilityComponent }
+            adb -s $target shell "settings put secure enabled_accessibility_services $merged" | Out-Null
+            adb -s $target shell 'settings put secure accessibility_enabled 1' | Out-Null
+            Write-Ok 'accessibility fallback enabled'
+        }
+    }
+
+    # Wake first: on a sleeping/dreaming device an activity start hangs.
+    adb -s $target shell 'input keyevent KEYCODE_WAKEUP' | Out-Null
+    adb -s $target shell "am start-foreground-service -n $Package/.PiPupService" | Out-Null
+
+    # Verify from this machine: Android TVs have no curl.
+    $state = $null
+    foreach ($attempt in 1..10) {
+        try {
+            $state = Invoke-RestMethod "http://${tvHost}:$Port/state" -TimeoutSec 2
+            break
+        } catch {
+            Start-Sleep -Seconds 1
+        }
+    }
+    if ($state) {
+        Write-Ok "running: v$($state.version) on http://${tvHost}:$Port (overlay=$($state.permissions.overlay))"
+        if (-not $state.permissions.overlay) {
+            Write-Fail 'overlay permission still missing - popups will stay invisible'
+        }
+    } else {
+        Write-Warn "no answer on http://${tvHost}:$Port/state yet; open the app once on the TV"
+    }
+
+    adb disconnect $target | Out-Null
+}
+
+Write-Host ''
+if ($failed -gt 0) {
+    Write-Fail "$failed of $($Devices.Count) device(s) failed"
+    exit 1
+}
+Write-Ok "done: $($Devices.Count) device(s)"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+#
+# PiPup installer: does the whole sideload dance for one or more Android TVs, including
+# the app-ops an app is not allowed to grant itself.
+#
+#   ./install.sh 192.168.1.10 192.168.1.11
+#   ./install.sh --power --apk PiPup.apk 192.168.1.10
+#
+# Without --apk the latest release APK is downloaded from GitHub.
+#
+# Why a script and not something inside the app: SYSTEM_ALERT_WINDOW and
+# REQUEST_INSTALL_PACKAGES are app-ops, and only adb/shell or the system can set them.
+# Every reinstall resets them, which is exactly the trap this script exists to avoid.
+
+set -uo pipefail
+
+PACKAGE="nl.rogro82.pipup"
+ADMIN_COMPONENT="$PACKAGE/.AdminReceiver"
+ACCESSIBILITY_COMPONENT="$PACKAGE/$PACKAGE.PiPupAccessibilityService"
+REPO="mhoogenbosch/PiPup"
+PORT=7979
+
+APK=""
+GRANT_POWER=0
+GRANT_ACCESSIBILITY=0
+FORCE_UNINSTALL=0
+DEVICES=()
+
+usage() {
+    cat <<EOF
+Usage: $0 [options] <tv-ip[:port]> [tv-ip ...]
+
+Options:
+  --apk <file>        APK to install (default: download the latest release)
+  --power             also grant device admin, so POST /power?state=off works
+  --accessibility     also enable the accessibility fallback for screen off
+                      (only needed where device admin cannot reach standby)
+  --force-uninstall   uninstall first when the signature differs
+                      (WARNING: wipes the app's stable device id, so Home Assistant
+                      sees a new device)
+  -h, --help          this text
+
+Requires adb on your PATH, and adb debugging enabled on the TV.
+EOF
+}
+
+log()  { printf '%s\n' "$*"; }
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$*"; }
+warn() { printf '  \033[33m!\033[0m %s\n' "$*"; }
+err()  { printf '  \033[31m✗\033[0m %s\n' "$*"; }
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --apk)              APK="${2:?--apk needs a file}"; shift 2 ;;
+        --power)            GRANT_POWER=1; shift ;;
+        --accessibility)    GRANT_ACCESSIBILITY=1; shift ;;
+        --force-uninstall)  FORCE_UNINSTALL=1; shift ;;
+        -h|--help)          usage; exit 0 ;;
+        -*)                 err "unknown option: $1"; usage; exit 2 ;;
+        *)                  DEVICES+=("$1"); shift ;;
+    esac
+done
+
+if [ ${#DEVICES[@]} -eq 0 ]; then
+    usage
+    exit 2
+fi
+
+command -v adb >/dev/null 2>&1 || { err "adb not found on PATH"; exit 1; }
+
+# ---------------------------------------------------------------- APK
+
+if [ -z "$APK" ]; then
+    if [ -f PiPup.apk ]; then
+        APK="PiPup.apk"
+        log "Using ./PiPup.apk"
+    else
+        command -v curl >/dev/null 2>&1 || { err "need curl to download the APK, or pass --apk"; exit 1; }
+        log "Downloading the latest release from github.com/$REPO ..."
+        url=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" \
+              | grep -o '"browser_download_url": *"[^"]*\.apk"' | head -1 | cut -d'"' -f4)
+        [ -n "$url" ] || { err "could not find an APK in the latest release"; exit 1; }
+        curl -fsSL -o PiPup.apk "$url" || { err "download failed"; exit 1; }
+        APK="PiPup.apk"
+        ok "downloaded $(basename "$url")"
+    fi
+fi
+[ -f "$APK" ] || { err "APK not found: $APK"; exit 1; }
+
+# ---------------------------------------------------------------- per device
+
+failed=0
+
+for device in "${DEVICES[@]}"; do
+    case "$device" in
+        *:*) target="$device"; host="${device%%:*}" ;;
+        *)   target="$device:5555"; host="$device" ;;
+    esac
+
+    log ""
+    log "=== $target ==="
+
+    if ! adb connect "$target" 2>&1 | grep -qE 'connected to'; then
+        err "cannot connect (adb debugging on? authorised on the TV?)"
+        failed=$((failed + 1))
+        continue
+    fi
+    adb -s "$target" wait-for-device
+
+    # install; a signature clash means a differently-signed build (e.g. the Play Store
+    # version) is installed and Android refuses to replace it in place
+    out=$(adb -s "$target" install -r "$APK" 2>&1)
+    if printf '%s' "$out" | grep -q 'INSTALL_FAILED_UPDATE_INCOMPATIBLE\|signatures do not match'; then
+        if [ "$FORCE_UNINSTALL" -eq 1 ]; then
+            warn "different signature: uninstalling first (device id is lost)"
+            adb -s "$target" uninstall "$PACKAGE" >/dev/null 2>&1
+            out=$(adb -s "$target" install -r "$APK" 2>&1)
+        else
+            err "another build of $PACKAGE is installed (different signature)."
+            err "re-run with --force-uninstall, or: adb -s $target uninstall $PACKAGE"
+            failed=$((failed + 1))
+            continue
+        fi
+    fi
+    if ! printf '%s' "$out" | grep -q 'Success'; then
+        err "install failed: $(printf '%s' "$out" | tr '\n' ' ')"
+        failed=$((failed + 1))
+        continue
+    fi
+    ok "installed $(basename "$APK")"
+
+    # The two app-ops that a reinstall resets and the app cannot set itself.
+    adb -s "$target" shell "appops set $PACKAGE SYSTEM_ALERT_WINDOW allow" >/dev/null 2>&1 \
+        && ok "overlay permission granted" || err "could not grant SYSTEM_ALERT_WINDOW"
+    adb -s "$target" shell "appops set $PACKAGE REQUEST_INSTALL_PACKAGES allow" >/dev/null 2>&1 \
+        && ok "self-update permission granted" || warn "could not grant REQUEST_INSTALL_PACKAGES"
+
+    # TCL only: lets Android restart the service after a low-memory kill. Every other
+    # brand answers "Unknown operation string", which is fine - nothing to grant there.
+    autostart=$(adb -s "$target" shell "cmd appops set $PACKAGE android:auto_start allow" 2>&1)
+    if printf '%s' "$autostart" | grep -q 'Unknown operation string'; then
+        log "  · no vendor auto-start op on this device (normal outside TCL)"
+    else
+        ok "auto-start op granted (TCL)"
+    fi
+
+    if [ "$GRANT_POWER" -eq 1 ]; then
+        admin=$(adb -s "$target" shell "dpm set-active-admin $ADMIN_COMPONENT" 2>&1)
+        if printf '%s' "$admin" | grep -qi 'Success\|now an active admin'; then
+            ok "device admin active (screen off available)"
+        else
+            warn "device admin refused: $(printf '%s' "$admin" | tr '\n' ' ')"
+        fi
+    fi
+
+    if [ "$GRANT_ACCESSIBILITY" -eq 1 ]; then
+        current=$(adb -s "$target" shell "settings get secure enabled_accessibility_services" 2>/dev/null | tr -d '\r')
+        merged=""
+        case "$current" in
+            *"$PACKAGE"*) ok "accessibility service already enabled" ;;
+            null|"")      merged="$ACCESSIBILITY_COMPONENT" ;;
+            *)            merged="$current:$ACCESSIBILITY_COMPONENT" ;;
+        esac
+        if [ -n "$merged" ]; then
+            adb -s "$target" shell "settings put secure enabled_accessibility_services $merged" >/dev/null 2>&1
+            adb -s "$target" shell "settings put secure accessibility_enabled 1" >/dev/null 2>&1
+            ok "accessibility fallback enabled"
+        fi
+    fi
+
+    # Bring the service up. On a sleeping/dreaming device an activity start hangs, so
+    # wake it first; the service start itself does not touch the foreground.
+    adb -s "$target" shell "input keyevent KEYCODE_WAKEUP" >/dev/null 2>&1
+    adb -s "$target" shell "am start-foreground-service -n $PACKAGE/.PiPupService" >/dev/null 2>&1
+
+    # Verify from this machine rather than from the TV: Android TVs have no curl.
+    state=""
+    if command -v curl >/dev/null 2>&1; then
+        for _ in 1 2 3 4 5 6 7 8 9 10; do
+            state=$(curl -fsS --max-time 2 "http://$host:$PORT/state" 2>/dev/null) && break
+            sleep 1
+        done
+    fi
+    if [ -n "$state" ]; then
+        version=$(printf '%s' "$state" | grep -o '"version":"[^"]*"' | cut -d'"' -f4)
+        overlay=$(printf '%s' "$state" | grep -o '"overlay":[a-z]*' | cut -d: -f2)
+        ok "running: v${version:-?} on http://$host:$PORT (overlay=${overlay:-?})"
+        [ "${overlay:-}" = "true" ] || err "overlay permission still missing - popups will stay invisible"
+    else
+        warn "no answer on http://$host:$PORT/state yet; open the app once on the TV"
+    fi
+
+    adb disconnect "$target" >/dev/null 2>&1
+done
+
+log ""
+if [ "$failed" -gt 0 ]; then
+    err "$failed of ${#DEVICES[@]} device(s) failed"
+    exit 1
+fi
+ok "done: ${#DEVICES[@]} device(s)"

--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,20 @@ streams) on your TV from your home-automation system, for **as long as you want*
   and dismiss), **BACK** dismisses without an action.
 - **Countdown bar** (since 0.3.0) — `showProgress: true` animates a progress bar over a finite duration.
 - **Urgency presets** (since 0.3.0) — `urgency: info|warning|critical` adds a blue/orange/red border.
+- **Custom border styling** (since 0.7.0) — `borderColor`, `borderWidth` and `cornerRadius` style the
+  popup frame yourself; each field overrides its part of the `urgency` preset, so the preset stays a
+  shorthand and `borderWidth: 0` switches its border off again. Also available on uploaded snapshots
+  (multipart), which previously ignored `urgency` and `showProgress` entirely.
+- **Screen on/off** (since 0.7.0) — `POST /power?state=on|off|toggle` wakes the TV or puts it in
+  standby, without a second integration for ADB or HDMI-CEC. `/state` publishes what is actually
+  possible on this device (`power.canSleep`, `power.sleepMethod`) instead of accepting a request it
+  cannot honour. See [Screen on/off](#screen-onoff).
+- **Permission reporting + installers** (since 0.7.0) — `/state` reports what the app was granted
+  (`permissions.overlay`, `installPackages`, vendor `autoStart`, `deviceAdmin`, `accessibility`) and the
+  status screen on the TV warns when the overlay permission is missing — until now that failure was
+  invisible: every popup was answered with HTTP 200 and nothing appeared. `install.sh` / `install.ps1`
+  ship with each release and do the whole install *including* the app-ops that an app cannot grant
+  itself and that every reinstall resets.
 - **Localization** (since 0.3.1) — the app UI follows the device language (English/Dutch).
 - **Lazy TTS engine** (since 0.4.0) — the speech engine is only bound when a popup actually carries
   a `tts` field and is released again after 60s idle. On Google TV devices this keeps the separate
@@ -85,17 +99,39 @@ authorization prompt on the TV (once per computer).
 
 ### Install
 
-Download the APK from the [releases](../../releases) page and install it with adb.
-If you have the original Play Store version installed you need to uninstall that first
-(different signature, same application id).
+Grab `install.sh` (Linux/macOS/WSL) or `install.ps1` (Windows) from the
+[releases](../../releases) page and point it at your TVs:
+
+```
+./install.sh 192.168.1.10 192.168.1.11          # downloads the latest APK itself
+./install.sh --power --apk PiPup.apk 192.168.1.10
+```
+
+It installs the APK, grants the app-ops below, starts the service and verifies over HTTP that the
+app is actually answering with the overlay permission in place. `--power` also activates the device
+admin (for screen off), `--accessibility` enables the fallback for that, and `--force-uninstall`
+handles a differently-signed build that is already installed — note that uninstalling wipes the
+app's stable device id, so Home Assistant sees a new device afterwards.
+
+<details>
+<summary>Doing it by hand</summary>
 
 ```
 adb connect <tv-ip>:5555
 adb install -r PiPup.apk
 adb shell appops set nl.rogro82.pipup SYSTEM_ALERT_WINDOW allow
+adb shell appops set nl.rogro82.pipup REQUEST_INSTALL_PACKAGES allow
 ```
 
-The second command grants the overlay permission, which has no settings UI on Android TV.
+The overlay permission has no settings UI on Android TV, and the install permission is what lets the
+app apply its own updates. **Both are app-ops**: an app cannot grant them to itself (that is
+shell/system territory), which is why they are handed out over adb — and why `adb install -r`
+**resets them**, so they have to be granted again after every install. `/state` and the status screen
+on the TV show whether the overlay permission is currently in place.
+
+If you have the original Play Store version installed you need to uninstall that first (different
+signature, same application id).
+</details>
 
 _After installation or updating, open the application once (or reboot the TV) to make sure the
 background service is running._ Starting the service without bringing the app to the foreground
@@ -175,6 +211,11 @@ trust boundary the network itself.
   automations from button events (e.g. unlocking a door), have the caller include an unguessable,
   single-use token in that callback URL and verify it on receipt — the
   [ha-pipup integration](https://github.com/mhoogenbosch/ha-pipup) does this automatically.
+- Since 0.7.0 the same unauthenticated port also accepts `POST /power`, so anyone who can reach the TV
+  can switch its screen on or off. That is annoying rather than dangerous, but it is a reason not to
+  grant the screen-off route (device admin / accessibility) on a TV you deliberately expose. Granting
+  nothing leaves `/power?state=off` returning 501, and the device admin only asks for `force-lock` —
+  no password, camera or wipe policies — so the worst an attacker gains is a TV that goes to standby.
 
 ## Integrating
 
@@ -249,6 +290,29 @@ buttons: the overlay only takes input focus when buttons are present, **OK** act
 button — the app POSTs `{"popup", "button", "label", "device", "name"}` to the callback and
 dismisses — and **BACK** dismisses without an action.
 
+Since 0.7.0 the border can be styled directly, beyond the three urgency presets:
+
+```json
+{
+  "borderColor": "#00E5FF",
+  "borderWidth": 10,
+  "cornerRadius": 28
+}
+```
+
+| Field          | Type / default                                                        |
+| -------------- | --------------------------------------------------------------------- |
+| `borderColor`  | String `[AA]RRGGBB` (default: the urgency color, else `#ffffff`)       |
+| `borderWidth`  | Integer pixels (default: the urgency width, else `4` when a color is given; `0` = no border) |
+| `cornerRadius` | Number pixels (default: `8` when a border is drawn, else `0`)          |
+
+Each field independently overrides the `urgency` preset, so the two combine: `urgency: "critical"`
+with `borderWidth: 2` keeps the red but makes it thin, and `borderWidth: 0` removes the preset's
+border while keeping any other styling. `cornerRadius` works without a border too, for rounded
+corners on a plain popup. Sizes are in **pixels**, like every other dimension in this API (media
+width, padding) — on a 1080p TV a border of 10 is comfortably visible. An unparseable color falls
+back to the default instead of dropping the popup.
+
 - `duration`: seconds to show the popup. **`0` or negative shows it indefinitely**, until `/cancel`
   is called or a new popup replaces it.
 - `id` (string, optional): identifies the popup. Re-sending a notify with the same `id` and identical
@@ -281,6 +345,11 @@ Form-fields:
 | imageWidth      | Integer (default=480)                        |
 | tts             | String (optional, spoken aloud, since 0.2.5) |
 | ttsLanguage     | String (optional BCP-47 tag, since 0.2.5)    |
+| urgency         | String info/warning/critical (since 0.7.0)   |
+| borderColor     | String (format=[AA]RRGGBB, since 0.7.0)      |
+| borderWidth     | Integer pixels (since 0.7.0)                 |
+| cornerRadius    | Number pixels (since 0.7.0)                  |
+| showProgress    | Boolean (default=false, since 0.7.0)         |
 
 `position` is an enum ranging from 0 to 4:
 
@@ -306,6 +375,59 @@ the visible popup has that id — e.g. `POST /cancel?id=doorbell`. If the visibl
 id the call is a no-op (HTTP 200 with an explanatory message), so a delayed "hide camera" automation
 cannot accidentally cancel a newer, unrelated popup.
 
+### Screen on/off
+
+| Property      | Value                        |
+| ------------- | ---------------------------- |
+| Path:         | /power?state=on\|off\|toggle |
+| Method:       | POST                         |
+
+Since 0.7.0. Answers with the result rather than a bare "accepted":
+
+```json
+{ "state": "off", "ok": true, "method": "device_admin", "screenOn": false }
+```
+
+HTTP 200 when it was carried out, **501** when this device has no way to do it, 400 on a missing or
+unknown `state`. (`screenOn` in the reply can lag one poll behind on `state=on`: the wake activity is
+still starting up.)
+
+**On** needs nothing: PiPup launches an invisible activity with `setTurnScreenOn(true)`, which is the
+supported way to wake a device. On HDMI-CEC setups waking the box also switches the TV to its input.
+
+**Off** is the one capability that can genuinely be missing, because no sideloaded app may put a
+device to sleep on its own. There are two routes, and PiPup uses whichever is granted (device admin
+first). Grant one **once**, over adb — `install.sh --power` / `--accessibility` do exactly this:
+
+```
+# route 1 (preferred): device admin. Only asks for force-lock, nothing else.
+adb shell dpm set-active-admin nl.rogro82.pipup/.AdminReceiver
+
+# route 2: accessibility fallback, for devices without the device-admin feature
+adb shell settings put secure enabled_accessibility_services \
+    nl.rogro82.pipup/nl.rogro82.pipup.PiPupAccessibilityService
+adb shell settings put secure accessibility_enabled 1
+```
+
+Route 2 exists because a fair number of Android TV boxes ship **without** the device-admin feature at
+all (`dumpsys device_policy` shows `mHasFeature=false`). Confusingly, `dpm set-active-admin` still
+prints `Success` there while nothing is registered — so trust `/state`, not `dpm`. Verified: a Fire TV
+stick (Fire OS, Android 9) locks via device admin, a Nokia Streaming Box 8010 (Android 14) has no
+device-admin feature and locks via the accessibility route.
+
+⚠️ **When appending to `enabled_accessibility_services`, keep the existing value** (colon-separated) —
+overwriting it disables other accessibility services, such as Projectivy Launcher's. The installer
+scripts append; the snippet above only holds for a device with none enabled.
+
+The accessibility service declares no event types and does not retrieve window content: it is bound
+purely so `GLOBAL_ACTION_LOCK_SCREEN` can be called, and reads nothing from your screen.
+
+`/state` publishes the capability so a client can hide a button it cannot honour:
+
+```json
+"power": { "canWake": true, "canSleep": true, "sleepMethod": "device_admin" }
+```
+
 ### State
 
 | Property      | Value            |
@@ -318,7 +440,7 @@ Returns the current state as JSON:
 ```json
 {
   "app": "PiPup",
-  "version": "0.3.1",
+  "version": "0.7.0",
   "id": "6f1f9c1e-4a3f-4a44-9d2c-6f1f9c1e4a3f",
   "name": "FireTV Veranda",
   "visible": true,
@@ -327,9 +449,20 @@ Returns the current state as JSON:
   "watchdogCleanups": 0,
   "uptime": 86400,
   "device": { "model": "AFTKA", "manufacturer": "Amazon", "android": "9" },
-  "popup": { "id": "doorbell", "duration": 0, "indefinite": true, "elapsed": 42 }
+  "popup": { "id": "doorbell", "duration": 0, "indefinite": true, "elapsed": 42 },
+  "power": { "canWake": true, "canSleep": true, "sleepMethod": "device_admin" },
+  "permissions": {
+    "overlay": true, "installPackages": true, "autoStart": null,
+    "deviceAdmin": true, "accessibility": false, "complete": true
+  }
 }
 ```
+
+Since v0.7.0 `permissions` reports what the app was actually granted, and `power` what it can do with
+the screen (see [Screen on/off](#screen-onoff)). `overlay: false` is the one to watch: popups are then
+accepted with HTTP 200 and stay invisible. `autoStart` is TCL's vendor app-op and is `null` on every
+device that does not have it — that is "not applicable", not a problem. `complete` is the short answer
+to "can this device show popups at all".
 
 Since v0.5.0 the response also contains `lastPopup`: the parameters of the last *received* popup
 (id, position, duration, muted, media type/size, tts, buttons, secondsAgo) — it survives dismiss/expiry,


### PR DESCRIPTION
Three field requests in one release.

## 1. Custom border styling

`borderColor` / `borderWidth` / `cornerRadius` on `/notify`. Each field overrides *its part* of the `urgency` preset, so the preset keeps working as a shorthand: `urgency: critical` + `borderWidth: 2` gives a thin red border, `borderWidth: 0` removes the preset's border, and `cornerRadius` works on a borderless popup too. Sizes are in pixels, consistent with every other dimension in this API (media width, padding).

The multipart path learned `urgency`, `showProgress` and the three border fields — it silently ignored the first two before, so uploaded snapshots could not be styled at all.

Also: colors now fall back to their default instead of throwing. An unparseable `titleColor` used to abort `create()` and drop the whole popup.

## 2. Screen on/off — `POST /power?state=on|off|toggle`

No second integration (ADB, CEC) needed for the common "wake the TV, then show something" case.

* **on** — an invisible, self-finishing activity with `setTurnScreenOn(true)`: the supported wake path. The deprecated wake lock is kept as a best-effort first attempt. On HDMI-CEC setups waking the box also switches the TV to its input.
* **off** — cannot be done by a sideloaded app on its own. Two routes, each a one-time adb grant: device admin `lockNow()` (asks for `force-lock` only, nothing else) and an accessibility service calling `GLOBAL_ACTION_LOCK_SCREEN` for devices that lack the device-admin feature. The service declares no event types and does not retrieve window content.

`/state` publishes `power.canSleep` + `power.sleepMethod`, and `/power` answers **501** when the device cannot, so a client can hide a control instead of offering one that quietly does nothing.

**Verified on hardware:**

| Device | Android | Wake | Sleep |
| --- | --- | --- | --- |
| Fire TV stick (AFTKA) | 9 (Fire OS) | yes | yes, `device_admin` |
| Nokia Streaming Box 8010 | 14 | yes | yes, `accessibility` |

The Nokia has no device-admin feature at all (`dumpsys device_policy` shows `mHasFeature=false`) — and `dpm set-active-admin` still prints `Success` there while registering nothing, which is precisely why the capability is probed from the app instead of assumed. That is also why the fallback route exists.

## 3. Installers + permission reporting

`SYSTEM_ALERT_WINDOW` and `REQUEST_INSTALL_PACKAGES` are app-ops: an app can never grant them to itself, and every `adb install -r` resets them. So the install path does it: `install.sh` / `install.ps1` (shipped as release assets) install the APK — downloaded from the latest release when not supplied — grant both app-ops plus TCL's `android:auto_start`, optionally the power grants (`--power`, `--accessibility`), start the service, and verify over HTTP that the app answers *with the overlay permission in place*. Multiple TVs per run.

Complementing that, `/state` reports `permissions` (overlay, installPackages, vendor autoStart, deviceAdmin, accessibility, complete) and the status screen on the TV warns when the overlay permission is missing. Until now that was an invisible failure: every `/notify` was answered with HTTP 200 while nothing appeared on screen.

Note for anyone scripting the accessibility grant by hand: **append** to `enabled_accessibility_services`, do not overwrite it — replacing the value disables other accessibility services (e.g. Projectivy Launcher's). The installers append.