### PR TITLE
installers: don't wake the TV to install (--wake for TCL)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -28,7 +28,11 @@ param(
     [switch]$Accessibility,
 
     # uninstall first on a signature clash (WARNING: wipes the stable device id)
-    [switch]$ForceUninstall
+    [switch]$ForceUninstall,
+
+    # wake the TV and start the app in the foreground instead of starting the service
+    # in the background; needed on TCL Google TVs, elsewhere it only switches the TV on
+    [switch]$Wake
 )
 
 $ErrorActionPreference = 'Continue'
@@ -154,9 +158,18 @@ foreach ($device in $Devices) {
         }
     }
 
-    # Wake first: on a sleeping/dreaming device an activity start hangs.
-    adb -s $target shell 'input keyevent KEYCODE_WAKEUP' | Out-Null
-    adb -s $target shell "am start-foreground-service -n $Package/.PiPupService" | Out-Null
+    # Deliberately not via the activity by default: a foreground-service start does not
+    # touch what is on screen, while waking a sleeping TV to install an app is exactly
+    # what you do not want on a set of them at once. -Wake is for TCL Google TVs, whose
+    # vendor guard freezes a background-started service; a dreaming device needs the key
+    # event first or `am start` hangs.
+    if ($Wake) {
+        adb -s $target shell 'input keyevent KEYCODE_WAKEUP' | Out-Null
+        adb -s $target shell 'input keyevent KEYCODE_HOME' | Out-Null
+        adb -s $target shell "am start -n $Package/.MainActivity" | Out-Null
+    } else {
+        adb -s $target shell "am start-foreground-service -n $Package/.PiPupService" | Out-Null
+    }
 
     # Verify from this machine: Android TVs have no curl.
     $state = $null

--- a/install.sh
+++ b/install.sh
@@ -24,6 +24,7 @@ APK=""
 GRANT_POWER=0
 GRANT_ACCESSIBILITY=0
 FORCE_UNINSTALL=0
+WAKE=0
 DEVICES=()
 
 usage() {
@@ -38,6 +39,10 @@ Options:
   --force-uninstall   uninstall first when the signature differs
                       (WARNING: wipes the app's stable device id, so Home Assistant
                       sees a new device)
+  --wake              wake the TV and start the app in the foreground instead of
+                      starting the service in the background. Needed on TCL Google
+                      TVs, whose vendor guard freezes a background-started service;
+                      elsewhere it just switches the TV on for no reason
   -h, --help          this text
 
 Requires adb on your PATH, and adb debugging enabled on the TV.
@@ -55,6 +60,7 @@ while [ $# -gt 0 ]; do
         --power)            GRANT_POWER=1; shift ;;
         --accessibility)    GRANT_ACCESSIBILITY=1; shift ;;
         --force-uninstall)  FORCE_UNINSTALL=1; shift ;;
+        --wake)             WAKE=1; shift ;;
         -h|--help)          usage; exit 0 ;;
         -*)                 err "unknown option: $1"; usage; exit 2 ;;
         *)                  DEVICES+=("$1"); shift ;;
@@ -168,10 +174,19 @@ for device in "${DEVICES[@]}"; do
         fi
     fi
 
-    # Bring the service up. On a sleeping/dreaming device an activity start hangs, so
-    # wake it first; the service start itself does not touch the foreground.
-    adb -s "$target" shell "input keyevent KEYCODE_WAKEUP" >/dev/null 2>&1
-    adb -s "$target" shell "am start-foreground-service -n $PACKAGE/.PiPupService" >/dev/null 2>&1
+    # Bring the service up. Deliberately NOT via the activity by default: a
+    # foreground-service start does not touch what is on screen, while waking a
+    # sleeping TV to install an app is exactly what you do not want on a set of
+    # them at once. --wake is for TCL Google TVs, where the vendor guard freezes a
+    # service that was started from the background - there the activity path is the
+    # working one, and a dreaming device needs the key event first or `am start` hangs.
+    if [ "$WAKE" -eq 1 ]; then
+        adb -s "$target" shell "input keyevent KEYCODE_WAKEUP" >/dev/null 2>&1
+        adb -s "$target" shell "input keyevent KEYCODE_HOME" >/dev/null 2>&1
+        adb -s "$target" shell "am start -n $PACKAGE/.MainActivity" >/dev/null 2>&1
+    else
+        adb -s "$target" shell "am start-foreground-service -n $PACKAGE/.PiPupService" >/dev/null 2>&1
+    fi
 
     # Verify from this machine rather than from the TV: Android TVs have no curl.
     state=""

--- a/readme.md
+++ b/readme.md
@@ -113,6 +113,10 @@ admin (for screen off), `--accessibility` enables the fallback for that, and `--
 handles a differently-signed build that is already installed — note that uninstalling wipes the
 app's stable device id, so Home Assistant sees a new device afterwards.
 
+Sleeping TVs are **left asleep**: the service is started in the background, which does not touch
+what is on screen. On a TCL Google TV use `--wake`, because its vendor guard freezes a service
+started from the background (see below) — there the app has to come up in the foreground.
+
 <details>
 <summary>Doing it by hand</summary>
 


### PR DESCRIPTION
Found while rolling v0.7.0 out to eight TVs.

`install.sh` / `install.ps1` sent `KEYCODE_WAKEUP` unconditionally, so installing on a set of sleeping TVs switched all of them on. That is never what you want, and it is unnecessary: `am start-foreground-service` does not touch the foreground — starting the app that way leaves a sleeping TV asleep.

The wake was there for the one case that does need it: on TCL Google TVs the vendor guard freezes a service started from the background, so the app has to come up as an activity, and `am start` hangs on a dreaming device unless it is woken first. That case is now an explicit `--wake` (bash) / `-Wake` (PowerShell) flag, documented in the readme next to the TCL section.

APK unchanged — installer scripts and readme only, so no version bump.