### PR TITLE
installers: verify the screen-off grant from /state, not from dpm

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -138,9 +138,13 @@ foreach ($device in $Devices) {
     }
 
     if ($Power) {
+        # NB: do not trust this command's output. On devices without the device-admin
+        # feature (a fair number of Android TV boxes) `dpm set-active-admin` reports
+        # Success while registering nothing at all - seen on both a Nokia Streaming Box
+        # 8010 and a TCL Google TV. The real check is /state below.
         $admin = (adb -s $target shell "dpm set-active-admin $AdminComponent" 2>&1) -join ' '
         if ($admin -match 'Success|now an active admin') {
-            Write-Ok 'device admin active (screen off available)'
+            Write-Host '  .  device admin requested (verifying below)'
         } else {
             Write-Warn "device admin refused: $admin"
         }
@@ -185,6 +189,15 @@ foreach ($device in $Devices) {
         Write-Ok "running: v$($state.version) on http://${tvHost}:$Port (overlay=$($state.permissions.overlay))"
         if (-not $state.permissions.overlay) {
             Write-Fail 'overlay permission still missing - popups will stay invisible'
+        }
+        if ($Power -or $Accessibility) {
+            if ($state.power.canSleep) {
+                Write-Ok "screen off available via $($state.power.sleepMethod)"
+            } else {
+                Write-Warn 'screen off NOT available: this device has no working device-admin'
+                Write-Warn 'feature (the dpm command reports Success anyway). Re-run with'
+                Write-Warn '-Accessibility to use the fallback route instead.'
+            }
         }
     } else {
         Write-Warn "no answer on http://${tvHost}:$Port/state yet; open the app once on the TV"

--- a/install.sh
+++ b/install.sh
@@ -151,9 +151,13 @@ for device in "${DEVICES[@]}"; do
     fi
 
     if [ "$GRANT_POWER" -eq 1 ]; then
+        # NB: do not trust this command's output. On devices without the device-admin
+        # feature (a fair number of Android TV boxes) `dpm set-active-admin` reports
+        # `Success` while registering nothing at all - seen on both a Nokia Streaming
+        # Box 8010 and a TCL Google TV. The real check is /state below.
         admin=$(adb -s "$target" shell "dpm set-active-admin $ADMIN_COMPONENT" 2>&1)
         if printf '%s' "$admin" | grep -qi 'Success\|now an active admin'; then
-            ok "device admin active (screen off available)"
+            log "  · device admin requested (verifying below)"
         else
             warn "device admin refused: $(printf '%s' "$admin" | tr '\n' ' ')"
         fi
@@ -201,6 +205,18 @@ for device in "${DEVICES[@]}"; do
         overlay=$(printf '%s' "$state" | grep -o '"overlay":[a-z]*' | cut -d: -f2)
         ok "running: v${version:-?} on http://$host:$PORT (overlay=${overlay:-?})"
         [ "${overlay:-}" = "true" ] || err "overlay permission still missing - popups will stay invisible"
+
+        if [ "$GRANT_POWER" -eq 1 ] || [ "$GRANT_ACCESSIBILITY" -eq 1 ]; then
+            can_sleep=$(printf '%s' "$state" | grep -o '"canSleep":[a-z]*' | cut -d: -f2)
+            method=$(printf '%s' "$state" | grep -o '"sleepMethod":"[^"]*"' | cut -d'"' -f4)
+            if [ "${can_sleep:-}" = "true" ]; then
+                ok "screen off available via ${method:-?}"
+            else
+                warn "screen off NOT available: this device has no working device-admin"
+                warn "feature (the dpm command reports Success anyway). Re-run with"
+                warn "--accessibility to use the fallback route instead."
+            fi
+        fi
     else
         warn "no answer on http://$host:$PORT/state yet; open the app once on the TV"
     fi

--- a/readme.md
+++ b/readme.md
@@ -415,9 +415,19 @@ adb shell settings put secure accessibility_enabled 1
 
 Route 2 exists because a fair number of Android TV boxes ship **without** the device-admin feature at
 all (`dumpsys device_policy` shows `mHasFeature=false`). Confusingly, `dpm set-active-admin` still
-prints `Success` there while nothing is registered — so trust `/state`, not `dpm`. Verified: a Fire TV
-stick (Fire OS, Android 9) locks via device admin, a Nokia Streaming Box 8010 (Android 14) has no
-device-admin feature and locks via the accessibility route.
+prints `Success` there while nothing is registered — so trust `/state`, not `dpm` (the installer
+scripts verify it that way and tell you to switch routes). Verified on hardware:
+
+| Device | Android | Screen on | Screen off |
+| --- | --- | --- | --- |
+| Fire TV stick (AFTKA) | 9 (Fire OS) | ✓ | ✓ device admin |
+| Nokia Streaming Box 8010 | 14 | ✓ | ✓ accessibility (no device-admin feature) |
+| TCL Google TV | 11 | ✓ | ✓ accessibility (no device-admin feature) |
+
+Two things seen while testing: a wake request that arrives **within a few seconds of putting the
+device to sleep** can be ignored while the sleep transition is still completing (a second call works),
+and on Android 13+ an accessibility service enabled over adb can be revoked again by the system — the
+switch's `can_sleep` attribute (and `/state`) show that immediately.
 
 ⚠️ **When appending to `enabled_accessibility_services`, keep the existing value** (colon-separated) —
 overwriting it disables other accessibility services, such as Projectivy Launcher's. The installer


### PR DESCRIPTION
Second thing found while rolling out to the fleet.

`dpm set-active-admin` prints `Success` on devices that have **no device-admin feature at all**, registering nothing — seen on a Nokia Streaming Box 8010 (Android 14) *and* a TCL Google TV (Android 11). So the installer cheerfully reported `device admin active (screen off available)` on exactly the two devices where screen off does not work through that route.

It now treats the `dpm` call as a request and verifies `power.canSleep` / `power.sleepMethod` in the `/state` it already fetches at the end, pointing at `--accessibility` when the admin route did not take.

Readme gains the hardware-verified table (Fire TV → device admin; Nokia 8010 and TCL → accessibility) and two edge cases found while testing:

- a wake request arriving **within a few seconds of a sleep** can be ignored while the sleep transition completes — a second call works;
- on Android 13+ the system can revoke an accessibility service that was enabled over adb (observed once on the Nokia, ~30 minutes after enabling). `can_sleep` in `/state` and on the HA switch shows that immediately.

APK unchanged — installers and readme only.