### PR TITLE
v0.8.0: permission screen with fix buttons, POST /permissions/fix

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "nl.rogro82.pipup"
         minSdkVersion 24
         targetSdkVersion 34
-        versionCode 22
-        versionName "0.7.0"
+        versionCode 23
+        versionName "0.8.0"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/app/src/main/java/nl/rogro82/pipup/MainActivity.kt
+++ b/app/src/main/java/nl/rogro82/pipup/MainActivity.kt
@@ -21,6 +21,8 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.view.View
+import android.widget.Button
+import android.widget.LinearLayout
 import android.widget.TextView
 import com.fasterxml.jackson.databind.JsonNode
 import nl.rogro82.pipup.Utils.getIpAddress
@@ -30,10 +32,13 @@ import java.net.URL
 class MainActivity : Activity() {
 
     private val mHandler = Handler(Looper.getMainLooper())
+
+    /// last rendered permission state; the panel is only rebuilt when it changes
+    private var mPermissionSignature: String? = null
     private val mRefresh = object : Runnable {
         override fun run() {
             refreshStatus()
-            refreshWarning()
+            refreshPermissions()
             mHandler.postDelayed(this, REFRESH_INTERVAL_MS)
         }
     }
@@ -84,13 +89,98 @@ class MainActivity : Activity() {
         mHandler.removeCallbacks(mRefresh)
     }
 
-    /// The one failure mode that looks like success from the outside: without the overlay
-    /// permission every /notify is answered with 200 and nothing appears on screen. Say so
-    /// here, on the only screen someone with a remote can reach, with the command to fix it.
-    /// Re-checked on every refresh so the warning disappears as soon as it is granted.
-    private fun refreshWarning() {
-        findViewById<TextView>(R.id.textViewWarning)?.visibility =
-            if (Permissions.overlay(this)) View.GONE else View.VISIBLE
+    /// Permission panel: the one class of failure that looks like success from the
+    /// outside. Without the overlay permission every /notify is answered with 200 and
+    /// nothing appears on screen, and `adb install -r` silently resets it again.
+    ///
+    /// So this screen - the only one someone with a remote can reach - shows the actual
+    /// state of each grant and, where the device has a screen for it, a button that goes
+    /// straight there. Where it has none (Fire OS answers those intents with do-nothing
+    /// CTS placeholders) it prints the adb command instead of a button that does nothing.
+    ///
+    /// Rebuilt on every refresh, so a permission granted elsewhere - by adb, or from
+    /// Home Assistant - turns green here within two seconds.
+    private fun refreshPermissions() {
+        val panel = findViewById<LinearLayout>(R.id.permissionsPanel) ?: return
+        val rows = Permissions.FIXABLE_KEYS.mapNotNull { key ->
+            val granted = Permissions.granted(this, key) ?: return@mapNotNull null
+            // Optional grants are only worth screen space when they are missing;
+            // the overlay is always shown, because everything depends on it.
+            if (granted && key != Permissions.KEY_OVERLAY) return@mapNotNull null
+            Triple(key, granted, Permissions.fixIntent(this, key) != null)
+        }
+
+        // Cheap redraw guard: rebuilding every 2s would fight the DPAD for focus.
+        val signature = rows.joinToString("|") { "${it.first}${it.second}${it.third}" }
+        if (signature == mPermissionSignature) return
+        mPermissionSignature = signature
+
+        panel.removeAllViews()
+        rows.forEach { (key, granted, fixable) -> panel.addView(permissionRow(key, granted, fixable)) }
+    }
+
+    private fun permissionRow(key: String, granted: Boolean, fixable: Boolean): View {
+        val row = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            gravity = android.view.Gravity.CENTER_HORIZONTAL
+            setPadding(0, 6, 0, 6)
+        }
+
+        val label = when (key) {
+            Permissions.KEY_OVERLAY -> R.string.permission_overlay
+            Permissions.KEY_INSTALL -> R.string.permission_install
+            Permissions.KEY_ADMIN -> R.string.permission_admin
+            else -> R.string.permission_accessibility
+        }
+        row.addView(TextView(this).apply {
+            text = getString(
+                if (granted) R.string.permission_line_ok else R.string.permission_line_missing,
+                getString(label)
+            )
+            textSize = 14f
+            gravity = android.view.Gravity.CENTER_HORIZONTAL
+            // a granted line is reassurance, a missing one is the message: only the
+            // second gets a colour that pulls the eye across the room
+            setTextColor(resources.getColor(if (granted) R.color.ok else R.color.warning))
+            if (!granted) setTypeface(typeface, android.graphics.Typeface.BOLD)
+        })
+
+        if (granted) return row
+
+        row.addView(TextView(this).apply {
+            text = getString(
+                when (key) {
+                    Permissions.KEY_OVERLAY -> R.string.permission_overlay_why
+                    Permissions.KEY_INSTALL -> R.string.permission_install_why
+                    Permissions.KEY_ADMIN -> R.string.permission_admin_why
+                    else -> R.string.permission_accessibility_why
+                }
+            )
+            textSize = 12f
+            gravity = android.view.Gravity.CENTER_HORIZONTAL
+        })
+
+        if (fixable) {
+            row.addView(
+                Button(this).apply {
+                    text = getString(R.string.permission_fix)
+                    isFocusable = true
+                    setOnClickListener { Permissions.launchFix(this@MainActivity, key) }
+                },
+                LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.WRAP_CONTENT,
+                    LinearLayout.LayoutParams.WRAP_CONTENT
+                ).apply { gravity = android.view.Gravity.CENTER_HORIZONTAL }
+            )
+        } else {
+            // no screen on this device: the command is the only honest answer
+            row.addView(TextView(this).apply {
+                text = Permissions.adbCommand(key)
+                textSize = 11f
+                setTextIsSelectable(false)
+            })
+        }
+        return row
     }
 
     /// Live status block below the server address. Fetched from the service's own

--- a/app/src/main/java/nl/rogro82/pipup/Permissions.kt
+++ b/app/src/main/java/nl/rogro82/pipup/Permissions.kt
@@ -1,7 +1,10 @@
 package nl.rogro82.pipup
 
 import android.app.AppOpsManager
+import android.app.admin.DevicePolicyManager
 import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import android.os.Build
 import android.provider.Settings
 import android.util.Log
@@ -55,14 +58,140 @@ object Permissions {
     /// power-related grants are reported separately: they are optional.
     fun complete(context: Context): Boolean = overlay(context)
 
+    fun granted(context: Context, key: String): Boolean? = when (key) {
+        KEY_OVERLAY -> overlay(context)
+        KEY_INSTALL -> installPackages(context)
+        // null = this platform has no device administration at all, which is a
+        // different answer from "not granted" - see PowerController.deviceAdminSupported
+        KEY_ADMIN -> if (PowerController.deviceAdminSupported(context)) {
+            PowerController.deviceAdminActive(context)
+        } else null
+        KEY_ACCESSIBILITY -> PiPupAccessibilityService.enabledInSettings(context)
+        KEY_AUTO_START -> autoStart(context)
+        else -> null
+    }
+
     fun asMap(context: Context): Map<String, Any?> = mapOf(
         "overlay" to overlay(context),
         "installPackages" to installPackages(context),
         "autoStart" to autoStart(context),
-        "deviceAdmin" to PowerController.deviceAdminActive(context),
+        "deviceAdmin" to granted(context, KEY_ADMIN),
         "accessibility" to PiPupAccessibilityService.enabledInSettings(context),
-        "complete" to complete(context)
+        "complete" to complete(context),
+        // which of these the app can hand to the user on screen (see fixIntent)
+        "fixable" to mapOf(
+            KEY_OVERLAY to (fixIntent(context, KEY_OVERLAY) != null),
+            KEY_INSTALL to (fixIntent(context, KEY_INSTALL) != null),
+            KEY_ADMIN to (fixIntent(context, KEY_ADMIN) != null),
+            KEY_ACCESSIBILITY to (fixIntent(context, KEY_ACCESSIBILITY) != null)
+        )
     )
 
+    /// The adb command that grants this one, for the devices where the on-screen
+    /// route does not exist. Shown on the TV and returned by /permissions/fix.
+    fun adbCommand(key: String): String = when (key) {
+        KEY_OVERLAY -> "adb shell appops set $PACKAGE SYSTEM_ALERT_WINDOW allow"
+        KEY_INSTALL -> "adb shell appops set $PACKAGE REQUEST_INSTALL_PACKAGES allow"
+        KEY_ADMIN -> "adb shell dpm set-active-admin $PACKAGE/.AdminReceiver"
+        KEY_ACCESSIBILITY ->
+            "adb shell settings put secure enabled_accessibility_services " +
+                    "<huidige waarde>:$PACKAGE/$PACKAGE.PiPupAccessibilityService"
+        KEY_AUTO_START -> "adb shell cmd appops set $PACKAGE android:auto_start allow"
+        else -> ""
+    }
+
+    /// Intent that takes the user to the screen where this permission is granted, or
+    /// null when this device has no such screen.
+    ///
+    /// "Has no such screen" is the interesting part. Every Android build must *resolve*
+    /// these actions to pass Google's compatibility suite, so a plain
+    /// `resolveActivity() != null` says yes even where nothing happens: Fire OS answers
+    /// with `CTSDummyIntentHandler`, Google TV with `frameworkpackagestubs.Stubs`.
+    /// Offering a button that visibly does nothing is worse than offering none, so those
+    /// placeholders count as absent and the adb command is shown instead.
+    fun fixIntent(context: Context, key: String): Intent? {
+        val intent = when (key) {
+            KEY_OVERLAY -> Intent(
+                Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
+                Uri.parse("package:${context.packageName}")
+            )
+            KEY_INSTALL -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                Intent(
+                    Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
+                    Uri.parse("package:${context.packageName}")
+                )
+            } else return null
+            KEY_ADMIN -> if (!PowerController.deviceAdminSupported(context)) return null
+            else Intent(DevicePolicyManager.ACTION_ADD_DEVICE_ADMIN).apply {
+                putExtra(
+                    DevicePolicyManager.EXTRA_DEVICE_ADMIN,
+                    AdminReceiver.component(context)
+                )
+                putExtra(
+                    DevicePolicyManager.EXTRA_ADD_EXPLANATION,
+                    context.getString(R.string.permission_admin_explanation)
+                )
+            }
+            KEY_ACCESSIBILITY -> Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS)
+            else -> return null
+        }
+        return intent.takeIf { isRealActivity(context, it) }
+    }
+
+    /// Put the screen that grants `key` in front of the user. Returns false when this
+    /// device has no such screen (then only adb can do it) or the launch was refused.
+    fun launchFix(context: Context, key: String): Boolean {
+        val intent = fixIntent(context, key) ?: return false
+        return try {
+            context.startActivity(intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+            true
+        } catch (ex: Throwable) {
+            Log.e(LOG_TAG, "Cannot open the screen for $key: ${ex.message}")
+            false
+        }
+    }
+
+    /// Bring PiPup's own status screen forward, which lists every permission with its
+    /// own fix button - the useful landing spot when nothing specific was asked for.
+    fun launchApp(context: Context): Boolean = try {
+        context.startActivity(
+            Intent(context, MainActivity::class.java)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        )
+        true
+    } catch (ex: Throwable) {
+        Log.e(LOG_TAG, "Cannot open the app: ${ex.message}")
+        false
+    }
+
+    /// First permission that is missing and has an on-screen route, if any.
+    fun firstMissing(context: Context): String? = FIXABLE_KEYS.firstOrNull {
+        granted(context, it) == false && fixIntent(context, it) != null
+    }
+
+    private fun isRealActivity(context: Context, intent: Intent): Boolean {
+        val name = try {
+            @Suppress("DEPRECATION")
+            context.packageManager.resolveActivity(intent, 0)?.activityInfo?.name
+        } catch (ex: Throwable) {
+            Log.e(LOG_TAG, "Cannot resolve ${intent.action}: ${ex.message}")
+            null
+        } ?: return false
+        return PLACEHOLDER_MARKERS.none { name.contains(it, ignoreCase = true) }
+    }
+
+    const val KEY_OVERLAY = "overlay"
+    const val KEY_INSTALL = "install"
+    const val KEY_ADMIN = "admin"
+    const val KEY_ACCESSIBILITY = "accessibility"
+    const val KEY_AUTO_START = "autoStart"
+
+    /// Order matters: this is what "fix the first thing that is missing" walks through.
+    val FIXABLE_KEYS = listOf(KEY_OVERLAY, KEY_INSTALL, KEY_ADMIN, KEY_ACCESSIBILITY)
+
+    private const val PACKAGE = "nl.rogro82.pipup"
     private const val OP_AUTO_START = "android:auto_start"
+
+    /// Class-name fragments of the do-nothing activities vendors ship to satisfy CTS.
+    private val PLACEHOLDER_MARKERS = listOf("CTSDummy", "frameworkpackagestubs")
 }

--- a/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
@@ -699,6 +699,59 @@ class PiPupService : Service(), WebServer.Handler {
         )
     }
 
+    /// POST /permissions/fix[?what=overlay|install|admin|accessibility|next]
+    ///
+    /// Puts the screen that grants a permission in front of the user. An app can never
+    /// grant these itself, but it can walk someone to the exact spot - which beats
+    /// telling a person with a remote in hand to go find an adb prompt.
+    ///
+    /// Without `what` it opens PiPup's own status screen, which lists every permission
+    /// with its own button; `what=next` jumps straight to the first missing one.
+    ///
+    /// The TV is woken first: a settings screen on a dark panel helps nobody.
+    /// 501 when this device has no such screen (Fire OS resolves these actions to
+    /// do-nothing CTS placeholders) - the response then carries the adb command.
+    private fun permissionFixResponse(session: NanoHTTPD.IHTTPSession): NanoHTTPD.Response {
+        val requested = session.parameters["what"]?.firstOrNull()?.lowercase()
+
+        val key = when (requested) {
+            null, "", "app", "status" -> null
+            "next" -> Permissions.firstMissing(this)
+                ?: return newFixedLengthResponse(
+                    NanoHTTPD.Response.Status.OK,
+                    APPLICATION_JSON,
+                    Json.writeValueAsString(
+                        mapOf("what" to "next", "ok" to true, "nothingMissing" to true)
+                    )
+                )
+            in Permissions.FIXABLE_KEYS -> requested
+            else -> return InvalidRequest(
+                "what must be one of ${Permissions.FIXABLE_KEYS}, 'next' or omitted"
+            )
+        }
+
+        PowerController.wake(this)
+
+        val ok = if (key == null) Permissions.launchApp(this)
+        else Permissions.launchFix(this, key)
+
+        val body = Json.writeValueAsString(
+            mapOf(
+                "what" to (key ?: "app"),
+                "ok" to ok,
+                "granted" to key?.let { Permissions.granted(this, it) },
+                // so a controller can show what to do where no screen exists
+                "adb" to key?.takeIf { !ok }?.let { Permissions.adbCommand(it) }
+            )
+        )
+        Log.d(LOG_TAG, "Permission fix ${key ?: "app"}: ok=$ok")
+        return newFixedLengthResponse(
+            if (ok) NanoHTTPD.Response.Status.OK else NanoHTTPD.Response.Status.NOT_IMPLEMENTED,
+            APPLICATION_JSON,
+            body
+        )
+    }
+
     /// Media summary for /state's lastPopup: {type, width, height?} or null.
     private fun mediaInfo(p: PopupProps): Map<String, Any?>? = when (val m = p.media) {
         is PopupProps.Media.Web -> mapOf("type" to "web", "width" to m.width, "height" to m.height)
@@ -741,6 +794,7 @@ class PiPupService : Service(), WebServer.Handler {
                             OK("update started")
                         }
                         "/power" -> powerResponse(session)
+                        "/permissions/fix" -> permissionFixResponse(session)
                         "/cancel" -> {
                             // optional ?id=<popup id>: only cancel when it matches the visible popup
                             val id = session.parameters["id"]?.firstOrNull()

--- a/app/src/main/java/nl/rogro82/pipup/PowerController.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PowerController.kt
@@ -3,6 +3,7 @@ package nl.rogro82.pipup
 import android.app.admin.DevicePolicyManager
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.PowerManager
 import android.util.Log
 
@@ -30,6 +31,19 @@ object PowerController {
 
     fun screenOn(context: Context): Boolean =
         (context.getSystemService(Context.POWER_SERVICE) as PowerManager).isInteractive
+
+    /// Whether this platform has device administration at all.
+    ///
+    /// Worth asking, because `dpm set-active-admin` happily reports `Success` on devices
+    /// that do not (measured on a Nokia Streaming Box 8010 and a TCL Google TV, both of
+    /// which register nothing). Reporting "not supported" instead of "not granted" keeps
+    /// anyone from chasing a grant that can never stick.
+    fun deviceAdminSupported(context: Context): Boolean = try {
+        context.packageManager.hasSystemFeature(PackageManager.FEATURE_DEVICE_ADMIN)
+    } catch (ex: Throwable) {
+        Log.e(LOG_TAG, "Cannot query device admin feature: ${ex.message}")
+        false
+    }
 
     fun deviceAdminActive(context: Context): Boolean = try {
         val dpm = context.getSystemService(Context.DEVICE_POLICY_SERVICE) as DevicePolicyManager

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -12,6 +12,7 @@
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent" app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintVertical_bias="0.15"
             android:src="@drawable/ic_banner"/>
     <TextView
             android:text="@string/server_running"
@@ -52,20 +53,29 @@
             app:layout_constraintTop_toBottomOf="@+id/textViewServerAddress"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"/>
-    <TextView
-            android:text="@string/warning_no_overlay"
+    <!-- Scrollable on purpose: a TV with several missing permissions would otherwise
+         push its own fix buttons off the bottom of the screen, and DPAD focus search
+         scrolls this into view by itself. Rows are built in code
+         (MainActivity.refreshPermissions) - which permissions exist, and whether they
+         can be granted on screen at all, differs per device. -->
+    <ScrollView
             android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:id="@+id/textViewWarning"
-            android:gravity="center_horizontal"
-            android:textColor="@color/warning"
-            android:textSize="13sp"
-            android:lineSpacingExtra="2dp"
-            android:visibility="gone"
-            android:layout_marginTop="16dp"
-            android:layout_marginStart="24dp"
-            android:layout_marginEnd="24dp"
+            android:layout_height="0dp"
+            android:id="@+id/permissionsScroll"
+            android:fillViewport="false"
+            android:layout_marginTop="12dp"
+            android:layout_marginBottom="8dp"
+            android:layout_marginStart="48dp"
+            android:layout_marginEnd="48dp"
             app:layout_constraintTop_toBottomOf="@+id/textViewStatus"
+            app:layout_constraintBottom_toTopOf="@+id/textViewInfo"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"/>
+            app:layout_constraintEnd_toEndOf="parent">
+        <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:id="@+id/permissionsPanel"
+                android:orientation="vertical"
+                android:gravity="center_horizontal"/>
+    </ScrollView>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -9,5 +9,16 @@
     <string name="update_available_message">Druk op OK om de update nu te installeren.</string>
     <string name="update_install">Installeren</string>
     <string name="accessibility_service_description">Hiermee kan PiPup het scherm op verzoek uitzetten. Alleen nodig op toestellen waar de apparaatbeheerder dat niet kan; PiPup leest niets van het scherm.</string>
-    <string name="warning_no_overlay">Geen overlay-permissie — popups worden aangenomen maar blijven onzichtbaar. Ken die eenmalig toe via adb:\nadb shell appops set nl.rogro82.pipup SYSTEM_ALERT_WINDOW allow</string>
+    <string name="permission_overlay">Overlay-permissie</string>
+    <string name="permission_install">Zelf-updaten</string>
+    <string name="permission_admin">Scherm uit (apparaatbeheerder)</string>
+    <string name="permission_accessibility">Scherm uit (toegankelijkheid)</string>
+    <string name="permission_line_ok">%1$s: toegekend</string>
+    <string name="permission_line_missing">%1$s: ONTBREEKT</string>
+    <string name="permission_overlay_why">Zonder dit worden popups aangenomen maar blijven ze onzichtbaar.</string>
+    <string name="permission_install_why">Nodig om app-updates zelf te installeren.</string>
+    <string name="permission_admin_why">Nodig om het scherm van deze tv op verzoek uit te zetten.</string>
+    <string name="permission_accessibility_why">Alternatieve route voor scherm uit, voor toestellen zonder apparaatbeheerder.</string>
+    <string name="permission_fix">Repareren</string>
+    <string name="permission_admin_explanation">Wordt alleen gebruikt om het scherm van deze tv op verzoek uit te zetten. Er wordt verder niets beheerd.</string>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,4 +1,5 @@
 <resources>
-    <!-- status screen: missing permission warning -->
-    <color name="warning">#FFB300</color>
+    <!-- permission panel on the status screen; both readable on the blue background -->
+    <color name="warning">#FFD54F</color>
+    <color name="ok">#DFF3E3</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,5 +13,16 @@
     <string name="update_available_message">Press OK to install the update now.</string>
     <string name="update_install">Install</string>
     <string name="accessibility_service_description">Lets PiPup turn the screen off on request. Only needed on devices where the device admin cannot; PiPup reads nothing from the screen.</string>
-    <string name="warning_no_overlay">No overlay permission — popups are accepted but stay invisible. Grant it once over adb:\nadb shell appops set nl.rogro82.pipup SYSTEM_ALERT_WINDOW allow</string>
+    <string name="permission_overlay">Overlay permission</string>
+    <string name="permission_install">Self-update permission</string>
+    <string name="permission_admin">Screen off (device admin)</string>
+    <string name="permission_accessibility">Screen off (accessibility)</string>
+    <string name="permission_line_ok">%1$s: granted</string>
+    <string name="permission_line_missing">%1$s: MISSING</string>
+    <string name="permission_overlay_why">Popups are accepted but stay invisible without it.</string>
+    <string name="permission_install_why">Needed to install app updates by itself.</string>
+    <string name="permission_admin_why">Needed to switch this TV\'s screen off on request.</string>
+    <string name="permission_accessibility_why">Alternative route for screen off, for devices without device admin.</string>
+    <string name="permission_fix">Fix</string>
+    <string name="permission_admin_explanation">Only used to turn this TV\'s screen off on request. No other policies are applied.</string>
 </resources>

--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,12 @@ streams) on your TV from your home-automation system, for **as long as you want*
   standby, without a second integration for ADB or HDMI-CEC. `/state` publishes what is actually
   possible on this device (`power.canSleep`, `power.sleepMethod`) instead of accepting a request it
   cannot honour. See [Screen on/off](#screen-onoff).
+- **Permission screen with fix buttons** (since 0.8.0) — the status screen on the TV lists every
+  permission with its actual state, and a **Fix** button next to the missing ones that jumps straight
+  to the system screen where it is granted, operable with the remote. `POST /permissions/fix` does
+  the same from a controller (the Home Assistant integration has a button, an action and a
+  self-fixing repair). Where a device has no such screen the app shows the adb command instead — see
+  [Permission screen](#permission-screen).
 - **Permission reporting + installers** (since 0.7.0) — `/state` reports what the app was granted
   (`permissions.overlay`, `installPackages`, vendor `autoStart`, `deviceAdmin`, `accessibility`) and the
   status screen on the TV warns when the overlay permission is missing — until now that failure was
@@ -442,6 +448,47 @@ purely so `GLOBAL_ACTION_LOCK_SCREEN` can be called, and reads nothing from your
 "power": { "canWake": true, "canSleep": true, "sleepMethod": "device_admin" }
 ```
 
+### Permission screen
+
+| Property      | Value                                                    |
+| ------------- | -------------------------------------------------------- |
+| Path:         | /permissions/fix[?what=overlay\|install\|admin\|accessibility\|next] |
+| Method:       | POST                                                     |
+
+Since 0.8.0. Puts the screen that grants a permission in front of the user and wakes the TV first.
+Without `what` it opens PiPup's own status screen, which lists every permission with its own **Fix**
+button; `what=next` jumps to the first missing one.
+
+```json
+{ "what": "overlay", "ok": true, "granted": false, "adb": null }
+```
+
+**The app still cannot grant anything itself** — these are app-ops, which only shell or the system
+may set. What it can do is walk someone holding a remote to the exact spot, which is the part that
+was missing.
+
+Whether that spot exists differs per device, and *asking* is not enough: every Android build must
+resolve these intents to pass Google's compatibility suite, so a plain "is there an activity for
+this?" says yes even where nothing happens. Fire OS answers with `CTSDummyIntentHandler`, Google TV
+with `frameworkpackagestubs.Stubs`. PiPup treats those placeholders as absent, because a button that
+visibly does nothing is worse than no button: `/state` then reports the permission as not fixable,
+`/permissions/fix` answers **501**, and both the TV screen and the reply carry the adb command.
+
+Measured on hardware:
+
+| | Fire OS 9 | Google TV 11 | Android 14 |
+| --- | --- | --- | --- |
+| Overlay permission | adb only | ✓ on screen | ✓ on screen |
+| Self-update permission | ✓ on screen | ✓ on screen | ✓ on screen |
+| Device admin | adb only | not supported by the platform | not supported by the platform |
+| Accessibility | adb only | adb only | ✓ on screen |
+
+`/state` publishes this as `permissions.fixable`, so a controller can show a button only where it
+leads somewhere. Note `deviceAdmin: null` on the last two: those platforms have no device
+administration at all (`hasSystemFeature(FEATURE_DEVICE_ADMIN)` is false) — a different answer from
+"not granted", and worth distinguishing because `dpm set-active-admin` reports `Success` there
+anyway.
+
 ### State
 
 | Property      | Value            |
@@ -467,7 +514,8 @@ Returns the current state as JSON:
   "power": { "canWake": true, "canSleep": true, "sleepMethod": "device_admin" },
   "permissions": {
     "overlay": true, "installPackages": true, "autoStart": null,
-    "deviceAdmin": true, "accessibility": false, "complete": true
+    "deviceAdmin": true, "accessibility": false, "complete": true,
+    "fixable": { "overlay": false, "install": true, "admin": false, "accessibility": false }
   }
 }
 ```


### PR DESCRIPTION
Follow-up to the permission reporting in 0.7.0: reporting a missing permission is useful, but the person looking at the TV still had to find an adb prompt.

## What it does

The status screen now lists every permission with its real state and a **Fix** button next to the missing ones, which jumps straight to the system screen where it is granted — operable with the remote. `POST /permissions/fix` does the same from a controller: no `what` opens the overview, `what=next` the first missing one, or name one specifically. The TV is woken first, because a settings screen on a dark panel helps nobody.

The app still **cannot grant anything itself** — these are app-ops, which only shell or the system may set. It can only walk someone to the exact spot.

## Not every device has that spot, and asking is not enough

Every Android build must *resolve* these intents to pass Google's compatibility suite, so `resolveActivity() != null` says yes even where nothing happens: Fire OS answers with `CTSDummyIntentHandler`, Google TV with `frameworkpackagestubs.Stubs`. Those placeholders are treated as absent — a button that visibly does nothing is worse than no button — and the adb command is shown instead. `/state` publishes `permissions.fixable` so a controller can make the same distinction.

Measured on hardware:

| | Fire OS 9 | Google TV 11 | Android 14 |
| --- | --- | --- | --- |
| Overlay permission | adb only | ✓ on screen | ✓ on screen |
| Self-update permission | ✓ on screen | ✓ on screen | ✓ on screen |
| Device admin | adb only | not supported by the platform | not supported by the platform |
| Accessibility | adb only | adb only | ✓ on screen |

Verified end-to-end on a TCL Google TV: a DPAD press on the Fix button opens `SystemAlertActivity`.

## Also

`deviceAdmin` is now **null** where the platform has no device administration at all (`hasSystemFeature(FEATURE_DEVICE_ADMIN)` false — the Nokia 8010 and the TCL) instead of `false`. A different answer from "not granted", and worth distinguishing: `dpm set-active-admin` reports `Success` on exactly those devices, so this also stops a fix button being offered for a grant that could never stick.

The permission panel sits in a `ScrollView`: a TV with several missing permissions would otherwise push its own fix buttons off the bottom of the screen.