### PR TITLE
installers: anchor the overlay check on "permissions"

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -202,7 +202,10 @@ for device in "${DEVICES[@]}"; do
     fi
     if [ -n "$state" ]; then
         version=$(printf '%s' "$state" | grep -o '"version":"[^"]*"' | cut -d'"' -f4)
-        overlay=$(printf '%s' "$state" | grep -o '"overlay":[a-z]*' | cut -d: -f2)
+        # Anchored on "permissions": since app 0.8.0 there is a second "overlay" key
+        # inside "fixable", and a loose match returned both values at once.
+        overlay=$(printf '%s' "$state" \
+            | grep -o '"permissions":{"overlay":[a-z]*' | cut -d: -f3)
         ok "running: v${version:-?} on http://$host:$PORT (overlay=${overlay:-?})"
         [ "${overlay:-}" = "true" ] || err "overlay permission still missing - popups will stay invisible"
 


### PR DESCRIPTION
Caught while rolling 0.8.0 out to the fleet.

0.8.0 added a second `"overlay"` key inside `permissions.fixable`, so `grep -o '"overlay":[a-z]*'` matched **both** and the check compared against `"true\nfalse"` — reporting the overlay permission as missing on TVs that had just been granted it, right below the line saying it had been granted.

Anchored on `"permissions":{"overlay":` instead. `install.ps1` is unaffected: it parses the JSON properly.

APK unchanged.