### PR TITLE
v0.8.1: don't wake the TV for a fix it cannot show

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "nl.rogro82.pipup"
         minSdkVersion 24
         targetSdkVersion 34
-        versionCode 23
-        versionName "0.8.0"
+        versionCode 24
+        versionName "0.8.1"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
@@ -730,6 +730,25 @@ class PiPupService : Service(), WebServer.Handler {
             )
         }
 
+        // Check before waking. Switching someone's TV on and then answering "this
+        // device cannot show that screen" is the worst of both worlds - seen for real
+        // when a failing request from Home Assistant still lit up a TV in another room.
+        if (key != null && Permissions.fixIntent(this, key) == null) {
+            Log.d(LOG_TAG, "Permission fix $key: no screen on this device")
+            return newFixedLengthResponse(
+                NanoHTTPD.Response.Status.NOT_IMPLEMENTED,
+                APPLICATION_JSON,
+                Json.writeValueAsString(
+                    mapOf(
+                        "what" to key,
+                        "ok" to false,
+                        "granted" to Permissions.granted(this, key),
+                        "adb" to Permissions.adbCommand(key)
+                    )
+                )
+            )
+        }
+
         PowerController.wake(this)
 
         val ok = if (key == null) Permissions.launchApp(this)


### PR DESCRIPTION
`/permissions/fix` woke the TV *before* checking whether the requested screen exists on that device, so a request that was going to answer 501 anyway still switched a TV on.

Seen for real minutes after releasing 0.8.0: a failing `pipup.fix_permission` call from Home Assistant, aimed at a Fire TV where the overlay screen is a CTS placeholder, woke a TV in another room and left it on. Switching someone's TV on and then telling them the device cannot do the thing is the worst of both worlds.

The capability check now runs first; the wake only happens when there is something to show. Verified on a sleeping Fire TV stick: the request answers 501 with the adb command and the TV stays asleep.