### PR TITLE
readme: an accessibility grant does not survive a reinstall either

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -439,6 +439,11 @@ switch's `can_sleep` attribute (and `/state`) show that immediately.
 overwriting it disables other accessibility services, such as Projectivy Launcher's. The installer
 scripts append; the snippet above only holds for a device with none enabled.
 
+⚠️ **Like the app-ops, this grant does not survive a reinstall.** Replacing the APK (`adb install -r`,
+including an update) drops the app out of the enabled list, and screen-off silently stops working —
+`/state` reports `power.canSleep: false` from then on. Re-run `install.sh --accessibility`, or include
+the flag in the install itself. The device admin route does not have this problem.
+
 The accessibility service declares no event types and does not retrieve window content: it is bound
 purely so `GLOBAL_ACTION_LOCK_SCREEN` can be called, and reads nothing from your screen.
 


### PR DESCRIPTION
Measured twice today on a Nokia Streaming Box 8010: after `adb install -r` the app is dropped from `enabled_accessibility_services`, so screen-off silently stops working on devices that depend on that route — `/state` then reports `power.canSleep: false`.

Same trap as the app-ops, and it belongs right next to them in the readme. The device admin route does not have this problem.

Docs only.