### PR TITLE
v0.9.0: diagnose why a fix button did not appear, and stop failing silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ Original app by [rogro82](https://github.com/rogro82/PiPup).
 Every version below has a [GitHub release](https://github.com/mhoogenbosch/PiPup/releases) with the
 full story (English and Dutch) and the APK.
 
+## [v0.9.0] — 2026-08-19 (diagnose why a fix button did not appear)
+Answer to a field report that the permission fix "does not work". Two causes, both invisible from the
+outside, plus the endpoint to see them.
+### Added
+- **`GET /permissions/diagnose`** — per permission the intent action, the activity that resolves it,
+  whether that activity is a vendor placeholder, whether it is fixable and the adb command; plus
+  `sdk`/`device`, `deviceAdminSupported`, `backgroundLaunchExempt`, `activityVisible` and `lastFix`
+  (what the previous attempt did and how it ended). Reachable over HTTP, so a bug report can carry facts
+  instead of a symptom — the people who hit this are holding a remote, not a shell. The Home Assistant
+  integration puts the whole block in its diagnostics download.
+- `<queries>` declarations for the four settings intents.
+### Fixed
+- **A fix requested while the overlay permission was missing did nothing and reported success.** From
+  Android 10 on, starting an activity from the background needs an exemption; holding
+  `SYSTEM_ALERT_WINDOW` is one, a foreground service explicitly is not — so the permission you most
+  want a button for is the one whose absence takes the button away, and the platform drops the launch
+  silently. `/permissions/fix` now checks up front and answers **501** with a `reason` naming the way
+  out: open PiPup on the TV (a visible window is another exemption) and use the button there, or use
+  adb. Verified all three ways on a TCL Google TV.
+- **Working screens were reported as unavailable on some devices.** The placeholder check used
+  `resolveActivity()`, which on Android 11+ is a query and is filtered by package visibility, while
+  `startActivity()` is not. Without `<queries>`, any device whose `forceQueryable` list omits Settings
+  hid a perfectly good button. An unresolved intent now counts as *worth trying*; only a recognised
+  placeholder (`CTSDummy…`, `frameworkpackagestubs…`) is refused. A Google TV here lists 184
+  `forceQueryable` packages including Settings, which is why this never showed up in testing.
+- The "is my window visible" check was a boolean set by `MainActivity`, so the wake step — which
+  launches `WakeActivity` in front of it — made a fix request refuse itself one step before launching.
+  The platform's exemption is per app, so it is now a counter over all activities.
+
 ## [v0.8.1] — 2026-08-17 (don't wake the TV for a fix it cannot show)
 ### Fixed
 - `POST /permissions/fix` woke the TV **before** checking whether the requested screen exists on that

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "nl.rogro82.pipup"
         minSdkVersion 24
         targetSdkVersion 34
-        versionCode 24
-        versionName "0.8.1"
+        versionCode 25
+        versionName "0.9.0"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,27 @@
          attempt next to WakeActivity's setTurnScreenOn. -->
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 
+    <!-- Package visibility (Android 11+): resolveActivity() is a *query* and is filtered,
+         even though startActivity() is not. Without these declarations the app cannot see
+         the settings screens it wants to send the user to, and would report a perfectly
+         working screen as unavailable on any device whose forceQueryable list omits
+         Settings. Measured: a Google TV listed 184 forceQueryable packages (Settings
+         among them), so this stayed invisible during development. -->
+    <queries>
+        <intent>
+            <action android:name="android.settings.action.MANAGE_OVERLAY_PERMISSION"/>
+        </intent>
+        <intent>
+            <action android:name="android.settings.MANAGE_UNKNOWN_APP_SOURCES"/>
+        </intent>
+        <intent>
+            <action android:name="android.settings.ACCESSIBILITY_SETTINGS"/>
+        </intent>
+        <intent>
+            <action android:name="android.app.action.ADD_DEVICE_ADMIN"/>
+        </intent>
+    </queries>
+
     <uses-feature
             android:name="android.hardware.touchscreen"
             android:required="false"/>

--- a/app/src/main/java/nl/rogro82/pipup/MainActivity.kt
+++ b/app/src/main/java/nl/rogro82/pipup/MainActivity.kt
@@ -81,11 +81,16 @@ class MainActivity : Activity() {
 
     override fun onResume() {
         super.onResume()
+        // A visible window is what makes the fix buttons work at all: it is one of the
+        // exemptions from the background-activity-launch restriction, and on a TV without
+        // the overlay permission it is the only one available.
+        Permissions.onActivityResumed()
         mHandler.post(mRefresh)
     }
 
     override fun onPause() {
         super.onPause()
+        Permissions.onActivityPaused()
         mHandler.removeCallbacks(mRefresh)
     }
 

--- a/app/src/main/java/nl/rogro82/pipup/Permissions.kt
+++ b/app/src/main/java/nl/rogro82/pipup/Permissions.kt
@@ -100,67 +100,111 @@ object Permissions {
         else -> ""
     }
 
-    /// Intent that takes the user to the screen where this permission is granted, or
-    /// null when this device has no such screen.
-    ///
-    /// "Has no such screen" is the interesting part. Every Android build must *resolve*
-    /// these actions to pass Google's compatibility suite, so a plain
-    /// `resolveActivity() != null` says yes even where nothing happens: Fire OS answers
-    /// with `CTSDummyIntentHandler`, Google TV with `frameworkpackagestubs.Stubs`.
-    /// Offering a button that visibly does nothing is worse than offering none, so those
-    /// placeholders count as absent and the adb command is shown instead.
-    fun fixIntent(context: Context, key: String): Intent? {
-        val intent = when (key) {
-            KEY_OVERLAY -> Intent(
-                Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
+    /// The intent for a permission screen, without judging whether it leads anywhere.
+    fun rawIntent(context: Context, key: String): Intent? = when (key) {
+        KEY_OVERLAY -> Intent(
+            Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
+            Uri.parse("package:${context.packageName}")
+        )
+        KEY_INSTALL -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            Intent(
+                Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
                 Uri.parse("package:${context.packageName}")
             )
-            KEY_INSTALL -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                Intent(
-                    Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
-                    Uri.parse("package:${context.packageName}")
-                )
-            } else return null
-            KEY_ADMIN -> if (!PowerController.deviceAdminSupported(context)) return null
-            else Intent(DevicePolicyManager.ACTION_ADD_DEVICE_ADMIN).apply {
-                putExtra(
-                    DevicePolicyManager.EXTRA_DEVICE_ADMIN,
-                    AdminReceiver.component(context)
-                )
-                putExtra(
-                    DevicePolicyManager.EXTRA_ADD_EXPLANATION,
-                    context.getString(R.string.permission_admin_explanation)
-                )
-            }
-            KEY_ACCESSIBILITY -> Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS)
-            else -> return null
+        } else null
+        KEY_ADMIN -> if (!PowerController.deviceAdminSupported(context)) null
+        else Intent(DevicePolicyManager.ACTION_ADD_DEVICE_ADMIN).apply {
+            putExtra(DevicePolicyManager.EXTRA_DEVICE_ADMIN, AdminReceiver.component(context))
+            putExtra(
+                DevicePolicyManager.EXTRA_ADD_EXPLANATION,
+                context.getString(R.string.permission_admin_explanation)
+            )
         }
-        return intent.takeIf { isRealActivity(context, it) }
+        KEY_ACCESSIBILITY -> Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS)
+        else -> null
+    }
+
+    /// Which activity would handle this intent, or null when nothing does *or* when the
+    /// platform hides it from us. Those two are not the same thing, which is the whole
+    /// reason [fixIntent] treats them differently.
+    fun resolvedActivity(context: Context, intent: Intent): String? = try {
+        @Suppress("DEPRECATION")
+        context.packageManager.resolveActivity(intent, 0)?.activityInfo?.name
+    } catch (ex: Throwable) {
+        Log.e(LOG_TAG, "Cannot resolve ${intent.action}: ${ex.message}")
+        null
+    }
+
+    /// A do-nothing activity that a vendor ships to satisfy Google's test suite.
+    fun isPlaceholder(activity: String?): Boolean =
+        activity != null && PLACEHOLDER_MARKERS.any { activity.contains(it, ignoreCase = true) }
+
+    /// Intent that takes the user to the screen where this permission is granted, or null
+    /// when this device has no such screen.
+    ///
+    /// Three outcomes, not two:
+    ///
+    /// * a real activity -> use it;
+    /// * a **placeholder** (Fire OS answers `CTSDummyIntentHandler`, Google TV
+    ///   `frameworkpackagestubs.Stubs`) -> refuse, because a button that visibly does
+    ///   nothing is worse than no button, and show the adb command instead;
+    /// * **nothing resolved** -> still try. `resolveActivity()` is a query, and queries are
+    ///   filtered by package visibility on Android 11+, while `startActivity()` is not - so
+    ///   "I cannot see it" does not mean "it is not there". Refusing here would hide a
+    ///   working button on any device whose forceQueryable list omits Settings.
+    fun fixIntent(context: Context, key: String): Intent? {
+        val intent = rawIntent(context, key) ?: return null
+        return if (isPlaceholder(resolvedActivity(context, intent))) null else intent
     }
 
     /// Put the screen that grants `key` in front of the user. Returns false when this
     /// device has no such screen (then only adb can do it) or the launch was refused.
     fun launchFix(context: Context, key: String): Boolean {
-        val intent = fixIntent(context, key) ?: return false
+        val intent = fixIntent(context, key)
+        if (intent == null) {
+            record(key, false, null, "no screen for this permission on this device")
+            return false
+        }
+        if (!canLaunchActivity(context)) {
+            record(key, false, null, BLOCKED_ERROR)
+            Log.w(LOG_TAG, "Not opening $key: $BLOCKED_ERROR")
+            return false
+        }
+        val activity = resolvedActivity(context, intent)
         return try {
             context.startActivity(intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+            record(key, true, activity, null)
             true
         } catch (ex: Throwable) {
+            // ActivityNotFoundException = the screen really is absent; anything else is
+            // usually the background-activity-launch restriction (see diagnose()).
             Log.e(LOG_TAG, "Cannot open the screen for $key: ${ex.message}")
+            record(key, false, activity, "${ex.javaClass.simpleName}: ${ex.message}")
             false
         }
     }
 
     /// Bring PiPup's own status screen forward, which lists every permission with its
     /// own fix button - the useful landing spot when nothing specific was asked for.
-    fun launchApp(context: Context): Boolean = try {
+    fun launchApp(context: Context): Boolean {
+        if (!canLaunchActivity(context)) {
+            record("app", false, "MainActivity", BLOCKED_ERROR)
+            Log.w(LOG_TAG, "Not opening the app: $BLOCKED_ERROR")
+            return false
+        }
+        return launchAppUnchecked(context)
+    }
+
+    private fun launchAppUnchecked(context: Context): Boolean = try {
         context.startActivity(
             Intent(context, MainActivity::class.java)
                 .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         )
+        record("app", true, "MainActivity", null)
         true
     } catch (ex: Throwable) {
         Log.e(LOG_TAG, "Cannot open the app: ${ex.message}")
+        record("app", false, "MainActivity", "${ex.javaClass.simpleName}: ${ex.message}")
         false
     }
 
@@ -169,16 +213,92 @@ object Permissions {
         granted(context, it) == false && fixIntent(context, it) != null
     }
 
-    private fun isRealActivity(context: Context, intent: Intent): Boolean {
-        val name = try {
-            @Suppress("DEPRECATION")
-            context.packageManager.resolveActivity(intent, 0)?.activityInfo?.name
-        } catch (ex: Throwable) {
-            Log.e(LOG_TAG, "Cannot resolve ${intent.action}: ${ex.message}")
-            null
-        } ?: return false
-        return PLACEHOLDER_MARKERS.none { name.contains(it, ignoreCase = true) }
+
+    /// Everything a remote helper needs to see why a fix button did or did not appear,
+    /// without asking the reporter for adb and a logcat.
+    fun diagnose(context: Context): Map<String, Any?> = mapOf(
+        "sdk" to Build.VERSION.SDK_INT,
+        "device" to mapOf(
+            "model" to Build.MODEL,
+            "manufacturer" to Build.MANUFACTURER,
+            "android" to Build.VERSION.RELEASE
+        ),
+        "permissions" to asMap(context),
+        // Starting an activity from the background is restricted from Android 10 on, and
+        // holding SYSTEM_ALERT_WINDOW is one of the exemptions - so the one case where the
+        // overlay permission is missing is also the case where opening its settings screen
+        // can be blocked. Worth reporting, because the failure is silent.
+        "backgroundLaunchExempt" to canLaunchActivity(context),
+        "activityVisible" to activityVisible,
+        "deviceAdminSupported" to PowerController.deviceAdminSupported(context),
+        "screens" to FIXABLE_KEYS.associateWith { key ->
+            val intent = rawIntent(context, key)
+            val resolved = intent?.let { resolvedActivity(context, it) }
+            mapOf(
+                "granted" to granted(context, key),
+                "action" to intent?.action,
+                "resolvedActivity" to resolved,
+                "placeholder" to isPlaceholder(resolved),
+                "fixable" to (fixIntent(context, key) != null),
+                "adb" to adbCommand(key)
+            )
+        },
+        "lastFix" to lastFix()
+    )
+
+    /// Outcome of the most recent fix attempt, so a report can show what actually happened
+    /// instead of "it does not work".
+    private fun lastFix(): Map<String, Any?>? {
+        val fix = mLastFix ?: return null
+        return fix + mapOf(
+            "secondsAgo" to (android.os.SystemClock.elapsedRealtime() - (fix["at"] as Long)) / 1000
+        ) - "at"
     }
+
+    private fun record(what: String, ok: Boolean, activity: String?, error: String?) {
+        mLastFix = mapOf(
+            "what" to what,
+            "ok" to ok,
+            "activity" to activity,
+            "error" to error,
+            "at" to android.os.SystemClock.elapsedRealtime()
+        )
+    }
+
+    /// written from HTTP worker threads, read by /permissions/diagnose
+    @Volatile
+    private var mLastFix: Map<String, Any?>? = null
+
+    /// How many of this app's activities are resumed right now.
+    ///
+    /// A counter, not a flag: the exemption the platform applies is "this *app* has a
+    /// visible window", and PiPup has more than one activity. A boolean set by
+    /// MainActivity alone read false the moment WakeActivity came up in front of it -
+    /// which is exactly what /permissions/fix does one step before launching - so a fix
+    /// requested on a sleeping TV refused itself.
+    private val mVisibleActivities = java.util.concurrent.atomic.AtomicInteger(0)
+
+    val activityVisible: Boolean
+        get() = mVisibleActivities.get() > 0
+
+    fun onActivityResumed() {
+        mVisibleActivities.incrementAndGet()
+    }
+
+    fun onActivityPaused() {
+        mVisibleActivities.updateAndGet { if (it > 0) it - 1 else 0 }
+    }
+
+    /// Whether this app may start an activity right now.
+    ///
+    /// From Android 10 on, starting an activity from the background is blocked unless the
+    /// app is exempt, and a foreground service is explicitly *not* an exemption. Holding
+    /// SYSTEM_ALERT_WINDOW is one - which produces a nasty circle: the case where the
+    /// overlay permission is missing is exactly the case where its own settings screen
+    /// cannot be opened. Worse, a blocked launch does not throw; it is silently dropped.
+    /// So this is checked up front instead of pretending the request succeeded.
+    fun canLaunchActivity(context: Context): Boolean =
+        activityVisible || overlay(context)
 
     const val KEY_OVERLAY = "overlay"
     const val KEY_INSTALL = "install"
@@ -188,6 +308,12 @@ object Permissions {
 
     /// Order matters: this is what "fix the first thing that is missing" walks through.
     val FIXABLE_KEYS = listOf(KEY_OVERLAY, KEY_INSTALL, KEY_ADMIN, KEY_ACCESSIBILITY)
+
+    /// Said in one line, because it travels to Home Assistant and into bug reports.
+    const val BLOCKED_ERROR =
+        "Android blocks starting an activity from the background unless the overlay " +
+                "permission is granted; open PiPup on the TV (or tap its notification) " +
+                "and use the button on its status screen"
 
     private const val PACKAGE = "nl.rogro82.pipup"
     private const val OP_AUTO_START = "android:auto_start"

--- a/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
@@ -699,6 +699,20 @@ class PiPupService : Service(), WebServer.Handler {
         )
     }
 
+    /// GET /permissions/diagnose - why a fix button did or did not appear.
+    ///
+    /// Exists so a bug report can carry facts instead of "it does not work": per
+    /// permission the intent action, which activity resolves it (or nothing), whether that
+    /// activity is a vendor placeholder, and the outcome of the last attempt. Reachable
+    /// without adb, which is the point - the people who hit this are holding a remote.
+    private fun diagnoseResponse(): NanoHTTPD.Response = newFixedLengthResponse(
+        NanoHTTPD.Response.Status.OK,
+        APPLICATION_JSON,
+        Json.writeValueAsString(
+            Permissions.diagnose(this) + mapOf("version" to BuildConfig.VERSION_NAME)
+        )
+    )
+
     /// POST /permissions/fix[?what=overlay|install|admin|accessibility|next]
     ///
     /// Puts the screen that grants a permission in front of the user. An app can never
@@ -733,17 +747,25 @@ class PiPupService : Service(), WebServer.Handler {
         // Check before waking. Switching someone's TV on and then answering "this
         // device cannot show that screen" is the worst of both worlds - seen for real
         // when a failing request from Home Assistant still lit up a TV in another room.
-        if (key != null && Permissions.fixIntent(this, key) == null) {
-            Log.d(LOG_TAG, "Permission fix $key: no screen on this device")
+        val refusal: String? = when {
+            key != null && Permissions.fixIntent(this, key) == null ->
+                "no screen for this permission on this device"
+            // Silently dropped by the platform otherwise - see Permissions.canLaunchActivity
+            !Permissions.canLaunchActivity(this) -> Permissions.BLOCKED_ERROR
+            else -> null
+        }
+        if (refusal != null) {
+            Log.d(LOG_TAG, "Permission fix ${key ?: "app"} refused: $refusal")
             return newFixedLengthResponse(
                 NanoHTTPD.Response.Status.NOT_IMPLEMENTED,
                 APPLICATION_JSON,
                 Json.writeValueAsString(
                     mapOf(
-                        "what" to key,
+                        "what" to (key ?: "app"),
                         "ok" to false,
-                        "granted" to Permissions.granted(this, key),
-                        "adb" to Permissions.adbCommand(key)
+                        "reason" to refusal,
+                        "granted" to key?.let { Permissions.granted(this, it) },
+                        "adb" to key?.let { Permissions.adbCommand(it) }
                     )
                 )
             )
@@ -793,6 +815,7 @@ class PiPupService : Service(), WebServer.Handler {
                 NanoHTTPD.Method.GET -> {
                     when(session.uri) {
                         "/state" -> stateResponse()
+                        "/permissions/diagnose" -> diagnoseResponse()
                         else -> InvalidRequest("unknown uri: ${session.uri}")
                     }
                 }
@@ -814,6 +837,7 @@ class PiPupService : Service(), WebServer.Handler {
                         }
                         "/power" -> powerResponse(session)
                         "/permissions/fix" -> permissionFixResponse(session)
+                        "/permissions/diagnose" -> diagnoseResponse()
                         "/cancel" -> {
                             // optional ?id=<popup id>: only cancel when it matches the visible popup
                             val id = session.parameters["id"]?.firstOrNull()

--- a/app/src/main/java/nl/rogro82/pipup/WakeActivity.kt
+++ b/app/src/main/java/nl/rogro82/pipup/WakeActivity.kt
@@ -16,6 +16,18 @@ import android.view.WindowManager
 /// recents and whatever was in the foreground comes straight back.
 class WakeActivity : Activity() {
 
+    override fun onResume() {
+        super.onResume()
+        // Counts towards the background-activity-launch exemption just like any other
+        // window of this app - and it is the window that is up while a fix is launched.
+        Permissions.onActivityResumed()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        Permissions.onActivityPaused()
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 

--- a/readme.md
+++ b/readme.md
@@ -489,7 +489,68 @@ Measured on hardware:
 | Accessibility | adb only | adb only | ✓ on screen |
 
 `/state` publishes this as `permissions.fixable`, so a controller can show a button only where it
-leads somewhere. Note `deviceAdmin: null` on the last two: those platforms have no device
+leads somewhere.
+
+#### The one case that cannot work remotely
+
+**Without the overlay permission, the fix screen cannot be opened from Home Assistant.** From Android
+10 on, starting an activity from the background is blocked unless the app is exempt, and holding
+`SYSTEM_ALERT_WINDOW` is one of the exemptions — while a foreground service is
+[explicitly not](https://developer.android.com/guide/components/activities/background-starts). So the
+one permission you most want a button for is the one whose absence takes the button away. A blocked
+launch does not even throw: the platform drops it silently.
+
+PiPup therefore checks up front and answers **501** with
+`reason: "Android blocks starting an activity from the background…"` instead of reporting success and
+doing nothing. The way out is a visible window of the app: **open PiPup on the TV** (from the launcher,
+or by tapping its ongoing notification — a notification tap is another exemption) and press the **Fix**
+button on its status screen, which is running in the foreground and therefore allowed. Or grant it over
+adb and never think about it again.
+
+Once the overlay permission *is* granted, everything else — `install`, `accessibility` — opens fine from
+Home Assistant with the app in the background.
+
+### Diagnosing "the fix button does nothing"
+
+| Property      | Value                     |
+| ------------- | ------------------------- |
+| Path:         | /permissions/diagnose     |
+| Method:       | GET (or POST)             |
+
+Since 0.9.0, and the first thing to attach to a bug report — no adb or logcat needed:
+
+```json
+{
+  "sdk": 30,
+  "device": { "model": "Smart TV", "manufacturer": "TCL", "android": "11" },
+  "backgroundLaunchExempt": true,
+  "activityVisible": false,
+  "deviceAdminSupported": false,
+  "screens": {
+    "overlay": {
+      "granted": true,
+      "action": "android.settings.action.MANAGE_OVERLAY_PERMISSION",
+      "resolvedActivity": "com.android.tv.settings.device.apps.specialaccess.SystemAlertActivity",
+      "placeholder": false,
+      "fixable": true,
+      "adb": "adb shell appops set nl.rogro82.pipup SYSTEM_ALERT_WINDOW allow"
+    }
+  },
+  "lastFix": { "what": "overlay", "ok": false, "activity": null, "error": "…", "secondsAgo": 42 }
+}
+```
+
+Read it as: `resolvedActivity` null means nothing handles that intent *or* the platform hides it from
+the app; `placeholder: true` means a vendor stub answered and a button would do nothing;
+`backgroundLaunchExempt: false` means no launch can happen at all right now (see above); and `lastFix`
+says how the previous attempt actually ended. The Home Assistant integration includes this block in its
+diagnostics download.
+
+Note on `resolvedActivity`: from Android 11 on, `resolveActivity()` is a *query* and queries are
+filtered by package visibility, while `startActivity()` is not — "I cannot see it" is not "it is not
+there". The app declares these intents in `<queries>` so it can see them, and treats an unresolved
+intent as worth trying rather than impossible. A device whose `forceQueryable` list omits Settings
+would otherwise hide a perfectly working button (`adb shell dumpsys package queries` shows that list). Note `deviceAdmin: null` on the last two: those platforms have no device
 administration at all (`hasSystemFeature(FEATURE_DEVICE_ADMIN)` is false) — a different answer from
 "not granted", and worth distinguishing because `dpm set-active-admin` reports `Success` there
 anyway.


### PR DESCRIPTION
A user reports that the permission fix does not work. Two causes, both invisible from the outside — plus the endpoint to see them without asking anyone for adb and a logcat.

## 1. Background activity starts are blocked without the overlay permission

From Android 10 on, [starting an activity from the background](https://developer.android.com/guide/components/activities/background-starts) needs an exemption. Holding `SYSTEM_ALERT_WINDOW` is one; a foreground service explicitly is **not**. So the one permission you most want a button for is the one whose absence takes the button away — and the platform drops such a launch *silently*, so `/permissions/fix` cheerfully answered 200 while nothing happened.

It now checks up front and answers **501** with a `reason` that names the way out: open PiPup on the TV (a visible window is another exemption) and press the Fix button there, or use adb. Reproduced and verified both ways on a TCL Google TV:

| overlay permission | app in foreground | before | now |
| --- | --- | --- | --- |
| granted | no | opens the screen | opens the screen |
| missing | no | 200, nothing happens | 501 + reason + adb command |
| missing | yes | opens the screen | opens the screen |

Caught while testing this: the wake step launches `WakeActivity`, which pauses `MainActivity` — so a boolean "my activity is visible" flag read false one step before the launch and the request refused itself. The platform's exemption is per *app*, not per activity, so it is now a counter over all activities with `WakeActivity` included.

## 2. `resolveActivity()` is filtered by package visibility; `startActivity()` is not

The placeholder check called `resolveActivity()` without declaring `<queries>`. On Android 11+ that is a filtered query, so on any device whose `forceQueryable` list omits Settings the app reported a perfectly working screen as unavailable — no button, and 501 from Home Assistant.

The four intents are now declared in `<queries>`, and an unresolved intent counts as **worth trying** rather than impossible; only a *recognised* vendor placeholder (`CTSDummy…`, `frameworkpackagestubs…`) is still refused, because that is the case where a button really would do nothing. Measured here: a Google TV lists 184 `forceQueryable` packages including Settings, which is exactly why this never showed up during development.

## The debug endpoint: `GET /permissions/diagnose`

```json
{
  "sdk": 30,
  "device": { "model": "Smart TV", "manufacturer": "TCL", "android": "11" },
  "backgroundLaunchExempt": true,
  "activityVisible": false,
  "deviceAdminSupported": false,
  "screens": {
    "overlay": {
      "granted": true,
      "action": "android.settings.action.MANAGE_OVERLAY_PERMISSION",
      "resolvedActivity": "com.android.tv.settings.device.apps.specialaccess.SystemAlertActivity",
      "placeholder": false,
      "fixable": true,
      "adb": "adb shell appops set nl.rogro82.pipup SYSTEM_ALERT_WINDOW allow"
    }
  },
  "lastFix": { "what": "overlay", "ok": false, "activity": null, "error": "…", "secondsAgo": 42 }
}
```

Reachable over HTTP, so a report can carry facts instead of a symptom — the people who hit this are holding a remote, not a shell. `lastFix` is what pinned down the flag bug above within a minute. The Home Assistant integration includes the whole block in its diagnostics download (ha-pipup 1.11.0).
