### PR TITLE
v0.9.1: device admin - report what is observable, not what a flag claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Original app by [rogro82](https://github.com/rogro82/PiPup).
 Every version below has a [GitHub release](https://github.com/mhoogenbosch/PiPup/releases) with the
 full story (English and Dutch) and the APK.
 
+## [v0.9.1] — 2026-08-19 (device admin: report what is observable)
+### Fixed
+- `permissions.deviceAdmin` reported `null` on a Fire TV stick (AFTKRT, Android 11) whose admin is
+  registered and whose `lockNow()` works — because `hasSystemFeature(FEATURE_DEVICE_ADMIN)` is false
+  there. `/state` then contradicted itself: `power.sleepMethod: "device_admin"` next to
+  `permissions.deviceAdmin: null`. An active admin is proof and now outranks the flag; `null` means
+  only "not active, and no sign the platform supports it".
+- The fix button for device admin no longer hides behind that flag either. Measured, the flag is wrong
+  in both directions (false where admins register, and reported true on Fire OS 9), so the honest
+  filter is the placeholder check that already refuses Fire OS's `CTSDummyDeviceAdminActivity`.
+
 ## [v0.9.0] — 2026-08-19 (diagnose why a fix button did not appear)
 Answer to a field report that the permission fix "does not work". Two causes, both invisible from the
 outside, plus the endpoint to see them.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "nl.rogro82.pipup"
         minSdkVersion 24
         targetSdkVersion 34
-        versionCode 25
-        versionName "0.9.0"
+        versionCode 26
+        versionName "0.9.1"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/app/src/main/java/nl/rogro82/pipup/Permissions.kt
+++ b/app/src/main/java/nl/rogro82/pipup/Permissions.kt
@@ -61,11 +61,16 @@ object Permissions {
     fun granted(context: Context, key: String): Boolean? = when (key) {
         KEY_OVERLAY -> overlay(context)
         KEY_INSTALL -> installPackages(context)
-        // null = this platform has no device administration at all, which is a
-        // different answer from "not granted" - see PowerController.deviceAdminSupported
-        KEY_ADMIN -> if (PowerController.deviceAdminSupported(context)) {
-            PowerController.deviceAdminActive(context)
-        } else null
+        // An active admin is proof, and it outranks any feature flag: measured on a Fire
+        // TV stick (AFTKRT, Android 11) that reports FEATURE_DEVICE_ADMIN as absent while
+        // `dumpsys device_policy` lists this app's AdminReceiver as an enabled admin and
+        // lockNow() works. Reporting null there contradicted /state's own sleepMethod.
+        // null therefore means only: not active, and no sign the platform supports it.
+        KEY_ADMIN -> when {
+            PowerController.deviceAdminActive(context) -> true
+            PowerController.deviceAdminSupported(context) -> false
+            else -> null
+        }
         KEY_ACCESSIBILITY -> PiPupAccessibilityService.enabledInSettings(context)
         KEY_AUTO_START -> autoStart(context)
         else -> null
@@ -112,8 +117,10 @@ object Permissions {
                 Uri.parse("package:${context.packageName}")
             )
         } else null
-        KEY_ADMIN -> if (!PowerController.deviceAdminSupported(context)) null
-        else Intent(DevicePolicyManager.ACTION_ADD_DEVICE_ADMIN).apply {
+        // No feature-flag gate: the flag is false on devices where admins demonstrably do
+        // register (see granted()), so the honest filter is the placeholder check in
+        // fixIntent() - Fire OS answers this action with CTSDummyDeviceAdminActivity.
+        KEY_ADMIN -> Intent(DevicePolicyManager.ACTION_ADD_DEVICE_ADMIN).apply {
             putExtra(DevicePolicyManager.EXTRA_DEVICE_ADMIN, AdminReceiver.component(context))
             putExtra(
                 DevicePolicyManager.EXTRA_ADD_EXPLANATION,

--- a/app/src/main/java/nl/rogro82/pipup/PowerController.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PowerController.kt
@@ -32,12 +32,14 @@ object PowerController {
     fun screenOn(context: Context): Boolean =
         (context.getSystemService(Context.POWER_SERVICE) as PowerManager).isInteractive
 
-    /// Whether this platform has device administration at all.
+    /// Whether this platform claims to have device administration. **A hint, not proof.**
     ///
-    /// Worth asking, because `dpm set-active-admin` happily reports `Success` on devices
-    /// that do not (measured on a Nokia Streaming Box 8010 and a TCL Google TV, both of
-    /// which register nothing). Reporting "not supported" instead of "not granted" keeps
-    /// anyone from chasing a grant that can never stick.
+    /// Measured three ways: a Nokia Streaming Box 8010 and a TCL Google TV report false and
+    /// register nothing (while `dpm set-active-admin` still prints `Success`), a Fire TV
+    /// stick on Fire OS 9 reports true and works - and a Fire TV stick on Fire OS 11
+    /// reports **false while an admin is registered and lockNow() works**. So this only
+    /// answers "is there any sign of support"; whether an admin is active is a separate
+    /// question with a reliable answer ([deviceAdminActive]).
     fun deviceAdminSupported(context: Context): Boolean = try {
         context.packageManager.hasSystemFeature(PackageManager.FEATURE_DEVICE_ADMIN)
     } catch (ex: Throwable) {


### PR DESCRIPTION
`/state` contradicted itself on a Fire TV stick (AFTKRT, Android 11):

```
"power":       { "canSleep": true, "sleepMethod": "device_admin" }
"permissions": { "deviceAdmin": null }
```

Cause is `hasSystemFeature(FEATURE_DEVICE_ADMIN)`, which is **false** on that device — while `dumpsys device_policy` lists `nl.rogro82.pipup/.AdminReceiver` as an enabled admin and `lockNow()` demonstrably works.

Measured across four devices, the flag is wrong in both directions:

| device | feature flag | admin registers | works |
| --- | --- | --- | --- |
| Fire TV stick, Fire OS 9 | true | yes | yes |
| Fire TV stick, Fire OS 11 | **false** | **yes** | **yes** |
| Nokia Streaming Box 8010 (14) | false | no (`dpm` still prints Success) | — |
| TCL Google TV (11) | false | no (`dpm` still prints Success) | — |

So an active admin is proof and now outranks the flag; `null` means only "not active, and no sign the platform supports it". The device-admin fix button no longer hides behind the flag either — the honest filter is the placeholder check that already refuses Fire OS's `CTSDummyDeviceAdminActivity`.

Reporting only; no behaviour change to screen on/off, which was already driven by `isAdminActive`.
