### PR TITLE
v0.10.0: status screen — calm, readable, and honest about what is optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ Original app by [rogro82](https://github.com/rogro82/PiPup).
 Every version below has a [GitHub release](https://github.com/mhoogenbosch/PiPup/releases) with the
 full story (English and Dutch) and the APK.
 
+## [v0.10.0] — 2026-08-22 (status screen: calm, readable, and honest about what is optional)
+All three from one field report (HA forum).
+### Changed
+- **Screen on/off is no longer presented as a problem.** A TV without the power grants showed a
+  permanent yellow *MISSING* with a Fix button — for a feature that is entirely optional — and its
+  owner understandably kept pressing it through disables, enables and reboots. The two power routes
+  (device admin / accessibility) are now ONE calm line: green *configured (via …)* when either route
+  works, neutral *optional, not configured* with a short explanation when neither does. Required
+  permissions (overlay, self-update) keep the loud treatment.
+- **The permission panel starts mid-screen** instead of at the bottom edge: compact logo/status header,
+  and the panel gets the whole lower half, so on most devices nothing needs scrolling.
+- **Bigger text** (18sp headline, 15sp explanation, 14sp adb command — was 14/12/11): this is a
+  10-foot UI and the old sizes were reported as "very difficult to see".
+
 ## [v0.9.1] — 2026-08-19 (device admin: report what is observable)
 ### Fixed
 - `permissions.deviceAdmin` reported `null` on a Fire TV stick (AFTKRT, Android 11) whose admin is

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "nl.rogro82.pipup"
         minSdkVersion 24
         targetSdkVersion 34
-        versionCode 26
-        versionName "0.9.1"
+        versionCode 27
+        versionName "0.10.0"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/app/src/main/java/nl/rogro82/pipup/MainActivity.kt
+++ b/app/src/main/java/nl/rogro82/pipup/MainActivity.kt
@@ -107,82 +107,109 @@ class MainActivity : Activity() {
     /// Home Assistant - turns green here within two seconds.
     private fun refreshPermissions() {
         val panel = findViewById<LinearLayout>(R.id.permissionsPanel) ?: return
-        val rows = Permissions.FIXABLE_KEYS.mapNotNull { key ->
-            val granted = Permissions.granted(this, key) ?: return@mapNotNull null
-            // Optional grants are only worth screen space when they are missing;
-            // the overlay is always shown, because everything depends on it.
-            if (granted && key != Permissions.KEY_OVERLAY) return@mapNotNull null
-            Triple(key, granted, Permissions.fixIntent(this, key) != null)
+
+        // Required grants first (missing = a real problem, shown loud), then screen
+        // on/off as ONE calm line: it is optional, so it must never look like an error.
+        // Field feedback drove this - a TV without the power grants showed a permanent
+        // yellow MISSING with a Fix button, and its owner understandably kept pressing it.
+        data class Row(
+            val label: String, val ok: Boolean, val optional: Boolean,
+            val why: Int?, val fixKey: String?, val adb: String?
+        )
+
+        val rows = buildList {
+            val overlay = Permissions.granted(this@MainActivity, Permissions.KEY_OVERLAY) == true
+            add(Row(
+                getString(R.string.permission_overlay), overlay, false,
+                R.string.permission_overlay_why.takeIf { !overlay },
+                Permissions.KEY_OVERLAY.takeIf { !overlay },
+                Permissions.adbCommand(Permissions.KEY_OVERLAY).takeIf { !overlay }
+            ))
+            val install = Permissions.granted(this@MainActivity, Permissions.KEY_INSTALL) == true
+            if (!install) add(Row(
+                getString(R.string.permission_install), false, false,
+                R.string.permission_install_why,
+                Permissions.KEY_INSTALL,
+                Permissions.adbCommand(Permissions.KEY_INSTALL)
+            ))
+            val method = PowerController.sleepMethod(this@MainActivity)
+            if (method != null) {
+                add(Row(getString(R.string.permission_power_set, method), true, true, null, null, null))
+            } else {
+                // whichever route has a real screen on this device; adb otherwise
+                val fixKey = listOf(Permissions.KEY_ADMIN, Permissions.KEY_ACCESSIBILITY)
+                    .firstOrNull { Permissions.fixIntent(this@MainActivity, it) != null }
+                add(Row(
+                    getString(R.string.permission_power), false, true,
+                    R.string.permission_power_why, fixKey,
+                    if (fixKey == null) Permissions.adbCommand(Permissions.KEY_ADMIN) else null
+                ))
+            }
         }
 
         // Cheap redraw guard: rebuilding every 2s would fight the DPAD for focus.
-        val signature = rows.joinToString("|") { "${it.first}${it.second}${it.third}" }
+        val signature = rows.joinToString("|") { "${it.label}${it.ok}${it.fixKey}" }
         if (signature == mPermissionSignature) return
         mPermissionSignature = signature
 
         panel.removeAllViews()
-        rows.forEach { (key, granted, fixable) -> panel.addView(permissionRow(key, granted, fixable)) }
+        rows.forEach { row ->
+            panel.addView(permissionRow(row.label, row.ok, row.optional, row.why, row.fixKey, row.adb))
+        }
     }
 
-    private fun permissionRow(key: String, granted: Boolean, fixable: Boolean): View {
+    private fun permissionRow(
+        label: String, ok: Boolean, optional: Boolean,
+        why: Int?, fixKey: String?, adb: String?
+    ): View {
         val row = LinearLayout(this).apply {
             orientation = LinearLayout.VERTICAL
             gravity = android.view.Gravity.CENTER_HORIZONTAL
-            setPadding(0, 6, 0, 6)
+            setPadding(0, 10, 0, 10)
         }
 
-        val label = when (key) {
-            Permissions.KEY_OVERLAY -> R.string.permission_overlay
-            Permissions.KEY_INSTALL -> R.string.permission_install
-            Permissions.KEY_ADMIN -> R.string.permission_admin
-            else -> R.string.permission_accessibility
-        }
         row.addView(TextView(this).apply {
-            text = getString(
-                if (granted) R.string.permission_line_ok else R.string.permission_line_missing,
-                getString(label)
-            )
-            textSize = 14f
+            text = when {
+                ok -> if (optional) label else getString(R.string.permission_line_ok, label)
+                optional -> getString(R.string.permission_line_optional, label)
+                else -> getString(R.string.permission_line_missing, label)
+            }
+            // 10-foot UI: field feedback called the old 14sp "very difficult to see"
+            textSize = 18f
             gravity = android.view.Gravity.CENTER_HORIZONTAL
-            // a granted line is reassurance, a missing one is the message: only the
-            // second gets a colour that pulls the eye across the room
-            setTextColor(resources.getColor(if (granted) R.color.ok else R.color.warning))
-            if (!granted) setTypeface(typeface, android.graphics.Typeface.BOLD)
+            setTextColor(resources.getColor(when {
+                ok -> R.color.ok
+                optional -> R.color.neutral   // optional-and-absent is information, not alarm
+                else -> R.color.warning
+            }))
+            if (!ok && !optional) setTypeface(typeface, android.graphics.Typeface.BOLD)
         })
 
-        if (granted) return row
-
-        row.addView(TextView(this).apply {
-            text = getString(
-                when (key) {
-                    Permissions.KEY_OVERLAY -> R.string.permission_overlay_why
-                    Permissions.KEY_INSTALL -> R.string.permission_install_why
-                    Permissions.KEY_ADMIN -> R.string.permission_admin_why
-                    else -> R.string.permission_accessibility_why
-                }
-            )
-            textSize = 12f
+        if (why != null) row.addView(TextView(this).apply {
+            text = getString(why)
+            textSize = 15f
             gravity = android.view.Gravity.CENTER_HORIZONTAL
         })
 
-        if (fixable) {
+        if (fixKey != null) {
             row.addView(
                 Button(this).apply {
                     text = getString(R.string.permission_fix)
                     isFocusable = true
-                    setOnClickListener { Permissions.launchFix(this@MainActivity, key) }
+                    setOnClickListener { Permissions.launchFix(this@MainActivity, fixKey) }
                 },
                 LinearLayout.LayoutParams(
                     LinearLayout.LayoutParams.WRAP_CONTENT,
                     LinearLayout.LayoutParams.WRAP_CONTENT
                 ).apply { gravity = android.view.Gravity.CENTER_HORIZONTAL }
             )
-        } else {
+        } else if (adb != null) {
             // no screen on this device: the command is the only honest answer
             row.addView(TextView(this).apply {
-                text = Permissions.adbCommand(key)
-                textSize = 11f
-                setTextIsSelectable(false)
+                text = adb
+                textSize = 14f
+                gravity = android.view.Gravity.CENTER_HORIZONTAL
+                setTextColor(resources.getColor(R.color.ok))
             })
         }
         return row

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,14 +5,17 @@
         android:layout_height="match_parent"
         android:layout_width="match_parent" android:layout_gravity="center" android:id="@+id/mainLayout"
         android:background="@color/ic_launcher_background">
+    <!-- Compact header: the permission panel below is what someone opens this screen
+         for (field feedback: it started at the bottom edge and needed scrolling). -->
     <ImageView
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_height="110dp"
+            android:adjustViewBounds="true"
             android:id="@+id/imageViewLogo"
+            android:layout_marginTop="20dp"
             app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent" app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintVertical_bias="0.15"
             android:src="@drawable/ic_banner"/>
     <TextView
             android:text="@string/server_running"
@@ -20,26 +23,17 @@
             android:layout_height="wrap_content"
             android:id="@+id/textViewConnection"
             app:layout_constraintTop_toBottomOf="@+id/imageViewLogo"
-            app:layout_constraintStart_toStartOf="@+id/imageViewLogo"
-            app:layout_constraintEnd_toEndOf="@+id/imageViewLogo" android:textStyle="bold"
-            android:layout_marginTop="16dp"/>
-    <TextView
-            android:text="@string/more_information"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:linksClickable="true"
-            android:id="@+id/textViewInfo"
-            app:layout_constraintBottom_toBottomOf="parent"
-            android:layout_marginBottom="24dp" app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" android:layout_marginStart="24dp"
-            android:layout_marginEnd="24dp"/>
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" android:textStyle="bold"
+            android:layout_marginTop="10dp"/>
     <TextView
             android:text="-"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:id="@+id/textViewServerAddress"
+            android:textSize="16sp"
             app:layout_constraintEnd_toEndOf="@+id/textViewConnection"
-            android:layout_marginTop="4dp" app:layout_constraintTop_toBottomOf="@+id/textViewConnection"
+            android:layout_marginTop="2dp" app:layout_constraintTop_toBottomOf="@+id/textViewConnection"
             app:layout_constraintStart_toStartOf="@+id/textViewConnection"/>
     <TextView
             android:text=""
@@ -49,26 +43,36 @@
             android:gravity="center_horizontal"
             android:lineSpacingExtra="3dp"
             android:textSize="14sp"
-            android:layout_marginTop="16dp"
+            android:layout_marginTop="8dp"
             app:layout_constraintTop_toBottomOf="@+id/textViewServerAddress"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"/>
-    <!-- Scrollable on purpose: a TV with several missing permissions would otherwise
-         push its own fix buttons off the bottom of the screen, and DPAD focus search
-         scrolls this into view by itself. Rows are built in code
-         (MainActivity.refreshPermissions) - which permissions exist, and whether they
-         can be granted on screen at all, differs per device. -->
+    <TextView
+            android:text="@string/more_information"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:linksClickable="true"
+            android:id="@+id/textViewInfo"
+            android:textSize="12sp"
+            android:layout_marginTop="6dp"
+            app:layout_constraintTop_toBottomOf="@+id/textViewStatus"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" android:layout_marginStart="24dp"
+            android:layout_marginEnd="24dp"/>
+    <!-- The permission panel gets the whole lower half. Scrollable on purpose (DPAD
+         focus search scrolls it), but with the larger layout most devices fit without
+         scrolling; rows are built in code (MainActivity.refreshPermissions). -->
     <ScrollView
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:id="@+id/permissionsScroll"
             android:fillViewport="false"
-            android:layout_marginTop="12dp"
-            android:layout_marginBottom="8dp"
-            android:layout_marginStart="48dp"
-            android:layout_marginEnd="48dp"
-            app:layout_constraintTop_toBottomOf="@+id/textViewStatus"
-            app:layout_constraintBottom_toTopOf="@+id/textViewInfo"
+            android:layout_marginTop="14dp"
+            android:layout_marginBottom="16dp"
+            android:layout_marginStart="64dp"
+            android:layout_marginEnd="64dp"
+            app:layout_constraintTop_toBottomOf="@+id/textViewInfo"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent">
         <LinearLayout

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -11,14 +11,14 @@
     <string name="accessibility_service_description">Hiermee kan PiPup het scherm op verzoek uitzetten. Alleen nodig op toestellen waar de apparaatbeheerder dat niet kan; PiPup leest niets van het scherm.</string>
     <string name="permission_overlay">Overlay-permissie</string>
     <string name="permission_install">Zelf-updaten</string>
-    <string name="permission_admin">Scherm uit (apparaatbeheerder)</string>
-    <string name="permission_accessibility">Scherm uit (toegankelijkheid)</string>
     <string name="permission_line_ok">%1$s: toegekend</string>
     <string name="permission_line_missing">%1$s: ONTBREEKT</string>
     <string name="permission_overlay_why">Zonder dit worden popups aangenomen maar blijven ze onzichtbaar.</string>
     <string name="permission_install_why">Nodig om app-updates zelf te installeren.</string>
-    <string name="permission_admin_why">Nodig om het scherm van deze tv op verzoek uit te zetten.</string>
-    <string name="permission_accessibility_why">Alternatieve route voor scherm uit, voor toestellen zonder apparaatbeheerder.</string>
     <string name="permission_fix">Repareren</string>
     <string name="permission_admin_explanation">Wordt alleen gebruikt om het scherm van deze tv op verzoek uit te zetten. Er wordt verder niets beheerd.</string>
+    <string name="permission_power">Scherm aan/uit</string>
+    <string name="permission_power_set">Scherm aan/uit: ingesteld (via %1$s)</string>
+    <string name="permission_line_optional">%1$s: optioneel, niet ingesteld</string>
+    <string name="permission_power_why">Alleen nodig als je het scherm van deze tv vanuit je domotica wilt uitzetten. Popups werken er prima zonder.</string>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,5 +1,6 @@
 <resources>
-    <!-- permission panel on the status screen; both readable on the blue background -->
+    <!-- permission panel on the status screen; all readable on the blue background -->
     <color name="warning">#FFD54F</color>
     <color name="ok">#DFF3E3</color>
+    <color name="neutral">#B9D4E2</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,14 +15,14 @@
     <string name="accessibility_service_description">Lets PiPup turn the screen off on request. Only needed on devices where the device admin cannot; PiPup reads nothing from the screen.</string>
     <string name="permission_overlay">Overlay permission</string>
     <string name="permission_install">Self-update permission</string>
-    <string name="permission_admin">Screen off (device admin)</string>
-    <string name="permission_accessibility">Screen off (accessibility)</string>
     <string name="permission_line_ok">%1$s: granted</string>
     <string name="permission_line_missing">%1$s: MISSING</string>
     <string name="permission_overlay_why">Popups are accepted but stay invisible without it.</string>
     <string name="permission_install_why">Needed to install app updates by itself.</string>
-    <string name="permission_admin_why">Needed to switch this TV\'s screen off on request.</string>
-    <string name="permission_accessibility_why">Alternative route for screen off, for devices without device admin.</string>
     <string name="permission_fix">Fix</string>
     <string name="permission_admin_explanation">Only used to turn this TV\'s screen off on request. No other policies are applied.</string>
+    <string name="permission_power">Screen on/off</string>
+    <string name="permission_power_set">Screen on/off: configured (via %1$s)</string>
+    <string name="permission_line_optional">%1$s: optional, not configured</string>
+    <string name="permission_power_why">Only needed if you want to switch this TV\'s screen off from your home automation. Popups work fine without it.</string>
 </resources>


### PR DESCRIPTION
All three from one field report (HA forum): an update that "failed", a Fix button that never went away no matter how many disables/enables/reboots, and "the scrolling messages at the bottom are very difficult to see".

## The Fix button that never goes away

That one is a design bug in the panel, not a permission problem on the reporter's TV. A TV without the screen-off grants showed a permanent yellow **MISSING** with a Fix button — for a feature that is *entirely optional* — so its owner understandably kept pressing it. Screen on/off is now **one calm line**:

* green *configured (via device_admin / accessibility)* when either route works — the other is irrelevant and no longer shown;
* neutral *optional, not configured* with one explanatory sentence ("Only needed if you want to switch this TV's screen off from your home automation. Popups work fine without it.") when neither does.

Required permissions (overlay, self-update) keep the loud yellow treatment. The distinction between *a problem* and *an option* is the whole point of the panel.

## Readability

* The panel starts **mid-screen**: compact logo/status header, panel gets the whole lower half. On a 720p set both missing-permission blocks now fit with their buttons without scrolling.
* Text sizes 14/12/11sp → **18/15/14sp**. This is a 10-foot UI.

Screenshots (TCL Google TV, 720p): all-good state shows two quiet lines; problem state shows both required blocks with their Fix buttons in view.

The reported update failure is the companion change in ha-pipup v1.11.1: the update entity now exposes `install_error`, `install_permission` and `requires_remote` (Android < 12 shows the system confirmation **on the TV**), so "it failed" carries its reason.
