### PR TITLE
v0.10.1: security/robustness audit fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ Original app by [rogro82](https://github.com/rogro82/PiPup).
 Every version below has a [GitHub release](https://github.com/mhoogenbosch/PiPup/releases) with the
 full story (English and Dutch) and the APK.
 
+## [v0.10.1] — 2026-08-22 (security/robustness audit)
+Full audit of the fork (all findings verified against a concrete failure scenario before fixing).
+### Security
+- **Request bodies are now capped at 256 KB.** `/notify` allocated a buffer of whatever
+  `Content-Length` claimed — one LAN request with a large header (or an unbounded chunked body) was an
+  out-of-memory crash of the service. Verified on hardware: a 900 MB Content-Length now gets HTTP 400
+  and the service stays up.
+### Fixed
+- **Popups longer than ~24.8 days vanished instantly**: the removal delay was computed as `Int * 1000`
+  before widening to `Long`, so it overflowed negative and removed the popup immediately.
+- **A self-update whose on-TV confirmation was never accepted blocked all future updates** until a
+  service restart: the "installing" flag never cleared. It is now a deadline (15 min) — an abandoned
+  attempt can be replaced.
+- **Every snapshot popup leaked one file descriptor** (`BitmapFactory.decodeStream` does not close its
+  stream); a corrupt upload now also gets a clean error instead of a null bitmap.
+- Removed the dead `CONNECTIVITY_CHANGE`/`WIFI_STATE_CHANGED` manifest filters: Android has not
+  delivered those broadcasts to manifest receivers since API 24/26, so the suggested
+  start-on-network-change never happened on any supported device.
+
 ## [v0.10.0] — 2026-08-22 (status screen: calm, readable, and honest about what is optional)
 All three from one field report (HA forum).
 ### Changed

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "nl.rogro82.pipup"
         minSdkVersion 24
         targetSdkVersion 34
-        versionCode 27
-        versionName "0.10.0"
+        versionCode 28
+        versionName "0.10.1"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -57,10 +57,12 @@
                 android:name=".Receiver"
                 android:enabled="true"
                 android:exported="true">
+            <!-- CONNECTIVITY_CHANGE / WIFI_STATE_CHANGED used to be here too, but
+                 Android has not delivered those implicit broadcasts to manifest
+                 receivers since API 24/26 - with minSdk 24 they were dead filters
+                 that only suggested a start-on-network-change that never happens. -->
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
-                <action android:name="android.net.conn.CONNECTIVITY_CHANGE" />
-                <action android:name="android.net.wifi.WIFI_STATE_CHANGED" />
             </intent-filter>
             <!-- Sent to this app after its own APK is replaced (self-update, or
                  `adb install -r`). Without it the service stays down after every

--- a/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
@@ -460,7 +460,8 @@ class PiPupService : Service(), WebServer.Handler {
         if (!popup.indefinite) {
             mHandler.postDelayed({
                 removePopup(true)
-            }, (popup.duration * 1000).toLong())
+            }, popup.duration * 1000L) // 1000L: an Int*Int product overflows past ~24.8 days
+                                        // and a negative delay removes the popup instantly
         }
     }
 
@@ -862,7 +863,14 @@ class PiPupService : Service(), WebServer.Handler {
                                         // fall back to draining the stream (chunked transfer /
                                         // clients that omit the header would otherwise parse as empty)
 
+                                        // Cap the body BEFORE allocating: this port is open to
+                                        // the whole LAN, and `ByteArray(contentLength)` with an
+                                        // attacker-chosen length is an OOM crash in one request.
+                                        // 256 KB fits any real popup many times over.
                                         val declaredLength = session.headers["content-length"]?.toIntOrNull()
+                                        if (declaredLength != null && declaredLength > MAX_JSON_BODY_BYTES) {
+                                            throw Exception("body too large ($declaredLength bytes, max $MAX_JSON_BODY_BYTES)")
+                                        }
                                         val content = if (declaredLength != null && declaredLength >= 0) {
                                             val buf = ByteArray(declaredLength)
                                             var read = 0
@@ -873,7 +881,18 @@ class PiPupService : Service(), WebServer.Handler {
                                             }
                                             buf
                                         } else {
-                                            session.inputStream.readBytes()
+                                            // chunked/no header: drain with the same ceiling
+                                            val out = java.io.ByteArrayOutputStream()
+                                            val buf = ByteArray(8192)
+                                            while (true) {
+                                                val res = session.inputStream.read(buf)
+                                                if (res < 0) break
+                                                out.write(buf, 0, res)
+                                                if (out.size() > MAX_JSON_BODY_BYTES) {
+                                                    throw Exception("body too large (max $MAX_JSON_BODY_BYTES)")
+                                                }
+                                            }
+                                            out.toByteArray()
                                         }
 
                                         Json.readValue(content, PopupProps::class.java)
@@ -915,12 +934,13 @@ class PiPupService : Service(), WebServer.Handler {
 
                                         val media = when(val image = files["image"]) {
                                             is String -> {
-                                                File(image).absoluteFile.let {
-                                                    val bitmap = BitmapFactory.decodeStream(it.inputStream())
-                                                    val imageWidth = params["imageWidth"]?.toIntOrNull() ?: PopupProps.DEFAULT_MEDIA_WIDTH
-
-                                                    PopupProps.Media.Bitmap(image = bitmap, width = imageWidth)
-                                                }
+                                                // use{}: decodeStream does not close its stream, so
+                                                // every snapshot popup leaked one file descriptor
+                                                val bitmap = File(image).absoluteFile.inputStream()
+                                                    .use { BitmapFactory.decodeStream(it) }
+                                                    ?: throw Exception("could not decode the uploaded image")
+                                                val imageWidth = params["imageWidth"]?.toIntOrNull() ?: PopupProps.DEFAULT_MEDIA_WIDTH
+                                                PopupProps.Media.Bitmap(image = bitmap, width = imageWidth)
                                             }
                                             else -> null
                                         }
@@ -989,6 +1009,7 @@ class PiPupService : Service(), WebServer.Handler {
         const val WEBSERVER_START_ATTEMPTS = 3
         const val WEBSERVER_RETRY_DELAY_MS = 500L
         const val TTS_IDLE_TIMEOUT_MS = 60_000L
+        const val MAX_JSON_BODY_BYTES = 256 * 1024
         const val MULTIPART_FORM_DATA = "multipart/form-data"
         const val APPLICATION_JSON = "application/json"
 

--- a/app/src/main/java/nl/rogro82/pipup/Receiver.kt
+++ b/app/src/main/java/nl/rogro82/pipup/Receiver.kt
@@ -7,10 +7,11 @@ import android.os.Build
 import android.util.Log
 import androidx.core.content.ContextCompat.startForegroundService
 
-/// Starts the service on boot, on network changes, and after the app's own APK is
-/// replaced. That last one matters for the self-updater: replacing the APK stops the
-/// app, and without MY_PACKAGE_REPLACED nothing brings the service back — the TV
-/// would silently drop off until the next reboot.
+/// Starts the service on boot and after the app's own APK is replaced. That second
+/// one matters for the self-updater: replacing the APK stops the app, and without
+/// MY_PACKAGE_REPLACED nothing brings the service back — the TV would silently drop
+/// off until the next reboot. (Network-change broadcasts are no longer delivered to
+/// manifest receivers on any supported Android, so there is no filter for them.)
 class Receiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {

--- a/app/src/main/java/nl/rogro82/pipup/UpdateManager.kt
+++ b/app/src/main/java/nl/rogro82/pipup/UpdateManager.kt
@@ -11,7 +11,7 @@ import android.util.Log
 import androidx.core.content.ContextCompat
 import java.net.HttpURLConnection
 import java.net.URL
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
 
 /// Self-update from the fork's GitHub releases.
 ///
@@ -29,6 +29,9 @@ object UpdateManager {
         "https://api.github.com/repos/mhoogenbosch/PiPup/releases/latest"
     private const val INSTALL_ACTION = "nl.rogro82.pipup.INSTALL_RESULT"
     private const val NET_TIMEOUT_MS = 15000
+    /// An attempt that has not concluded within this window is considered abandoned
+    /// (typically: the on-TV confirmation was never accepted) and may be replaced.
+    private const val INSTALL_TIMEOUT_MS = 15 * 60 * 1000L
 
     /// Result of the most recent check; read by /state on the web-server thread.
     @Volatile var latestVersion: String? = null
@@ -40,8 +43,17 @@ object UpdateManager {
     @Volatile var lastError: String? = null
         private set
 
-    private val installing = AtomicBoolean(false)
-    val isInstalling: Boolean get() = installing.get()
+    /// 0 = idle; otherwise the elapsedRealtime the current attempt started at. A
+    /// timestamp instead of a boolean, because an attempt can die without its result
+    /// receiver ever firing: pre-Android-12 the system confirmation has to be accepted
+    /// ON the TV, and a dialog nobody accepts (screen off, remote out of reach) used to
+    /// leave the flag stuck true forever - every later install answered "an update is
+    /// already running" until the service restarted. Seen in the field.
+    private val installStartedAt = AtomicLong(0)
+    val isInstalling: Boolean
+        get() = installStartedAt.get().let {
+            it != 0L && android.os.SystemClock.elapsedRealtime() - it < INSTALL_TIMEOUT_MS
+        }
 
     /// True when GitHub advertises a release newer than the running build.
     val updateAvailable: Boolean
@@ -85,7 +97,15 @@ object UpdateManager {
     /// asynchronously in the install receiver).
     fun installLatest(context: Context): String? {
         val url = downloadUrl ?: return "no download URL (run a check first)"
-        if (!installing.compareAndSet(false, true)) return "an update is already running"
+        val now = android.os.SystemClock.elapsedRealtime()
+        val running = installStartedAt.get()
+        if (running != 0L && now - running < INSTALL_TIMEOUT_MS) {
+            return "an update is already running"
+        }
+        // idle, or a stale attempt past its deadline: claim (or steal) the slot
+        if (!installStartedAt.compareAndSet(running, now)) {
+            return "an update is already running"
+        }
 
         return try {
             val conn = (URL(url).openConnection() as HttpURLConnection).apply {
@@ -97,7 +117,7 @@ object UpdateManager {
             if (conn.responseCode != 200) {
                 return "download failed: HTTP ${conn.responseCode}".also {
                     Log.w(LOG_TAG, it)
-                    installing.set(false)
+                    installStartedAt.set(0)
                 }
             }
 
@@ -126,7 +146,7 @@ object UpdateManager {
             Log.i(LOG_TAG, "Update session $sessionId committed for v$latestVersion")
             null
         } catch (ex: Throwable) {
-            installing.set(false)
+            installStartedAt.set(0)
             "install failed: ${ex.message ?: ex.javaClass.simpleName}".also {
                 Log.e(LOG_TAG, it, ex)
             }
@@ -170,13 +190,13 @@ object UpdateManager {
                         }
                         PackageInstaller.STATUS_SUCCESS -> {
                             Log.i(LOG_TAG, "Update installed")
-                            installing.set(false)
+                            installStartedAt.set(0)
                         }
                         else -> {
                             val msg = intent.getStringExtra(PackageInstaller.EXTRA_STATUS_MESSAGE)
                             lastError = "install status $status: $msg"
                             Log.w(LOG_TAG, lastError!!)
-                            installing.set(false)
+                            installStartedAt.set(0)
                         }
                     }
                 }


### PR DESCRIPTION
Full audit of the fork (correctness, concurrency, network robustness, security, parsing). Every finding below was verified against a concrete failure scenario before it was fixed; the first three were also re-verified on hardware after the fix.

| # | Severity | Finding | Fix |
|---|---|---|---|
| 1 | **High (LAN DoS)** | `/notify` allocated `ByteArray(Content-Length)` with an attacker-chosen length, and the chunked fallback drained unbounded — one request with `Content-Length: 900000000` OOM-crashed the service | Bodies capped at 256 KB, checked **before** allocation; chunked drain stops at the same ceiling. Verified: 400 + service stays up |
| 2 | Medium | A self-update whose on-TV confirmation (Android < 12) was never accepted left `installing` stuck `true` forever — every later install answered "an update is already running" until a service restart | The flag is now a 15-minute deadline; an abandoned attempt can be replaced |
| 3 | Low | `duration * 1000` overflowed `Int` past ~24.8 days → negative delay → popup removed instantly | `1000L`. Verified: `duration: 2200000` stays up |
| 4 | Low | Every snapshot popup leaked one file descriptor (`BitmapFactory.decodeStream` does not close its stream); a corrupt image produced a null bitmap | `use {}` + clean error on undecodable input |
| 5 | Info | `CONNECTIVITY_CHANGE`/`WIFI_STATE_CHANGED` manifest filters are dead: Android stopped delivering those to manifest receivers at API 24/26, and minSdk is 24 | Removed, docs corrected |

Also checked and found sound: the GitHub update path (HTTPS hardcoded, `RECEIVER_NOT_EXPORTED`, `setPackage` on the result intent, signature enforcement by the platform), the Jackson setup (fixed subtypes, no default typing), the button-callback echo, and the placeholder detection. The unauthenticated LAN server and the JS webview remain documented design decisions (README Security).

Companion: ha-pipup v1.11.2 (mjpeg signature vs. per-device indefinite default, and a switch settle-timer that could outlive its entity).
