### PR TITLE
v0.10.2: diagnose — raw app-op modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Original app by [rogro82](https://github.com/rogro82/PiPup).
 Every version below has a [GitHub release](https://github.com/mhoogenbosch/PiPup/releases) with the
 full story (English and Dutch) and the APK.
 
+## [v0.10.2] — 2026-08-23 (diagnose: raw app-op modes)
+Field follow-up: a TV whose *Install unknown apps* screen shows **Allowed** while the app reports the
+self-update permission as MISSING. Those two really can disagree, and the boolean could not say why.
+### Added
+- `/permissions/diagnose` now reports the **raw app-op modes** (`opModes`) for the install and overlay
+  grants. The interesting value is `default` — the state every reinstall resets to, for which
+  `canRequestPackageInstalls()` answers **false** on the devices measured here, whatever a Settings
+  toggle may show. Also new: `installCheckError` (a swallowed exception in the check used to be
+  indistinguishable from a revoked permission), `user` (app-ops are per profile — a Settings screen
+  viewed under another profile shows that profile's state) and `targetSdk`.
+
 ## [v0.10.1] — 2026-08-22 (security/robustness audit)
 Full audit of the fork (all findings verified against a concrete failure scenario before fixing).
 ### Security

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "nl.rogro82.pipup"
         minSdkVersion 24
         targetSdkVersion 34
-        versionCode 28
-        versionName "0.10.1"
+        versionCode 29
+        versionName "0.10.2"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/app/src/main/java/nl/rogro82/pipup/Permissions.kt
+++ b/app/src/main/java/nl/rogro82/pipup/Permissions.kt
@@ -30,11 +30,43 @@ object Permissions {
     /// REQUEST_INSTALL_PACKAGES - needed for the self-update to install its download.
     fun installPackages(context: Context): Boolean = try {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            context.packageManager.canRequestPackageInstalls()
+            context.packageManager.canRequestPackageInstalls().also {
+                mInstallCheckError = null
+            }
         } else true
     } catch (ex: Throwable) {
+        // Remember the failure: a swallowed exception here reports as MISSING and is
+        // indistinguishable from a genuinely revoked permission - diagnose() shows it.
+        mInstallCheckError = "${ex.javaClass.simpleName}: ${ex.message}"
         Log.e(LOG_TAG, "Cannot query install permission: ${ex.message}")
         false
+    }
+
+    @Volatile
+    private var mInstallCheckError: String? = null
+
+    /// Raw app-op mode ("allowed"/"ignored"/"errored"/"default"/...), or why it cannot
+    /// be read. The interesting one is **default**: that is what every reinstall resets
+    /// the op to, and canRequestPackageInstalls() answers false for it on the devices
+    /// measured here - while a Settings screen may still show a friendly toggle. The
+    /// raw mode tells those states apart where the boolean cannot.
+    fun opMode(context: Context, op: String): String = try {
+        val ops = context.getSystemService(Context.APP_OPS_SERVICE) as AppOpsManager
+        val mode = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            ops.unsafeCheckOpNoThrow(op, android.os.Process.myUid(), context.packageName)
+        } else {
+            @Suppress("DEPRECATION")
+            ops.checkOpNoThrow(op, android.os.Process.myUid(), context.packageName)
+        }
+        when (mode) {
+            AppOpsManager.MODE_ALLOWED -> "allowed"
+            AppOpsManager.MODE_IGNORED -> "ignored"
+            AppOpsManager.MODE_ERRORED -> "errored"
+            AppOpsManager.MODE_DEFAULT -> "default"
+            else -> "mode $mode"
+        }
+    } catch (ex: Throwable) {
+        "unavailable: ${ex.message}"
     }
 
     /// TCL's vendor app-op that decides whether Android may restart a killed service.
@@ -231,6 +263,17 @@ object Permissions {
             "android" to Build.VERSION.RELEASE
         ),
         "permissions" to asMap(context),
+        // Raw app-op modes: the boolean above collapses "default" (what a reinstall
+        // resets to) and "ignored" into the same false - these do not.
+        "opModes" to mapOf(
+            "installPackages" to opMode(context, "android:request_install_packages"),
+            "overlay" to opMode(context, "android:system_alert_window")
+        ),
+        "installCheckError" to mInstallCheckError,
+        // App-ops are per user: a Settings screen looked at under another profile
+        // (e.g. a kids profile on Google TV) shows that profile's state, not ours.
+        "user" to android.os.Process.myUserHandle().toString(),
+        "targetSdk" to context.applicationInfo.targetSdkVersion,
         // Starting an activity from the background is restricted from Android 10 on, and
         // holding SYSTEM_ALERT_WINDOW is one of the exemptions - so the one case where the
         // overlay permission is missing is also the case where opening its settings screen


### PR DESCRIPTION
Field follow-up on the permission work: a user's TV shows **Allowed** on the *Install unknown apps* settings screen, while the app's status screen reports **Self-update permission: MISSING** — with screenshots of both.

Those two really can disagree. Measured on Android 14: with the app-op in mode **`default`** — the state every reinstall resets it to — `canRequestPackageInstalls()` answers **false**, whatever a toggle shows. And our boolean collapsed `default`, `ignored` and "the check itself threw" into the same `false`, so the diagnose endpoint could describe the symptom but not the cause.

`/permissions/diagnose` now also reports:

- **`opModes`** — the raw app-op mode (`allowed` / `ignored` / `errored` / `default` / …) for the install and overlay grants;
- **`installCheckError`** — a swallowed exception in `canRequestPackageInstalls()` used to be indistinguishable from a revoked permission;
- **`user`** — app-ops are per profile: a Settings screen viewed under another profile (Google TV kids profiles, for instance) shows *that profile's* state, not the app's;
- **`targetSdk`**.

Verified on a Fire TV stick: mode `default` → `opModes.installPackages: "default"` + `installPackages: false`; mode `allow` → `"allowed"` + `true`.

Diagnostics only — no behaviour change.
