### PR TITLE
v0.11.0: visible updates, and a confirmation that can actually be confirmed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ Original app by [rogro82](https://github.com/rogro82/PiPup).
 Every version below has a [GitHub release](https://github.com/mhoogenbosch/PiPup/releases) with the
 full story (English and Dutch) and the APK.
 
+## [v0.11.0] — 2026-08-23 (visible updates, and a confirmation that can actually be confirmed)
+Field report: pressing Install in Home Assistant made "a screen flash by" on the TV and then nothing.
+Diagnosed on hardware: on Android < 12 the installer's confirmation dialog, launched blind from a
+background receiver, flashes and vanishes (TCL, Android 11) — the session then waits forever on a
+dialog nobody can reach. On Android 12+ the install is silent and over in seconds, so nothing ever
+acknowledged the button press.
+### Added
+- **"Installing PiPup vX…" popup** (with countdown bar) when an update starts via `POST /update` or
+  the app's own update popup.
+- **Confirmation popup with a button** when the installer demands on-screen confirmation
+  (Android < 12): pressing OK launches the system dialog from a *visible window*, so it keeps focus
+  instead of flashing away. Repeatable — `POST /update` while a confirmation is pending shows the
+  popup again instead of answering "already running".
+- **"PiPup updated to vX" popup** after the app replaced itself (screen on only; suppressed on the
+  very first run of a version that introduces the marker).
+### Notes
+- These flows run in the *new* version, so they become visible from the next update cycle onward —
+  updating *to* 0.11.0 still uses the old, silent code.
+
 ## [v0.10.2] — 2026-08-23 (diagnose: raw app-op modes)
 Field follow-up: a TV whose *Install unknown apps* screen shows **Allowed** while the app reports the
 self-update permission as MISSING. Those two really can disagree, and the boolean could not say why.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "nl.rogro82.pipup"
         minSdkVersion 24
         targetSdkVersion 34
-        versionCode 29
-        versionName "0.10.2"
+        versionCode 30
+        versionName "0.11.0"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
@@ -85,6 +85,16 @@ class PiPupService : Service(), WebServer.Handler {
         registerNsd()
         startWatchdog()
         startUpdateChecker()
+
+        // Android < 12: the installer wants an on-screen confirmation. Launched blind
+        // from the background that dialog flashes and vanishes; announced as a popup
+        // with a button it works, because the button press gives this app a visible
+        // window and an activity started from one keeps focus.
+        UpdateManager.onPendingUserAction = {
+            mHandler.post { showConfirmInstallPopup() }
+        }
+
+        maybeAnnounceInstalledUpdate()
         // TTS is initialised lazily: the engine is a separate ~100MB process and keeping it
         // bound for the entire service lifetime is the single biggest reason this app gets
         // picked by low-memory killers on 1GB TVs. Popups without `tts` never need it.
@@ -430,6 +440,69 @@ class PiPupService : Service(), WebServer.Handler {
         }, UPDATE_CHECK_FIRST_DELAY_MS)
     }
 
+    /// "Update to vX is being installed" - the visible feedback that pressing Install
+    /// used to lack: on Android 12+ the whole install is silent and over in seconds,
+    /// so nothing on the TV acknowledged the request at all.
+    private fun showInstallingPopup() {
+        val version = UpdateManager.latestVersion ?: return
+        createPopup(
+            PopupProps(
+                duration = 30,
+                id = UPDATE_POPUP_ID,
+                position = PopupProps.Position.BottomRight,
+                title = getString(R.string.update_installing_title, version),
+                message = getString(R.string.update_installing_message),
+                showProgress = true
+            )
+        )
+    }
+
+    /// Popup with a button that (re)launches the system's install confirmation
+    /// (Android < 12). Repeatable: POST /update while a confirmation is pending shows
+    /// it again instead of answering "already running".
+    private fun showConfirmInstallPopup() {
+        val version = UpdateManager.latestVersion ?: return
+        createPopup(
+            PopupProps(
+                duration = 120,
+                id = CONFIRM_POPUP_ID,
+                position = PopupProps.Position.BottomRight,
+                title = getString(R.string.update_confirm_title, version),
+                message = getString(R.string.update_confirm_message),
+                buttons = listOf(
+                    PopupProps.Button("confirm_install", getString(R.string.update_install))
+                )
+            )
+        )
+    }
+
+    /// One-time "updated to vX" popup after the app replaced itself, so an update that
+    /// happened silently (Android 12+) is still visibly acknowledged. Only when the
+    /// screen is on; the version marker is bumped regardless, so it never shows stale.
+    private fun maybeAnnounceInstalledUpdate() {
+        val prefs = getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val previous = prefs.getString(PREF_LAST_RUN_VERSION, null)
+        prefs.edit().putString(PREF_LAST_RUN_VERSION, BuildConfig.VERSION_NAME).apply()
+        if (previous == null || previous == BuildConfig.VERSION_NAME) return
+
+        val power = getSystemService(Context.POWER_SERVICE) as PowerManager
+        if (!power.isInteractive) return
+        // small delay: right after MY_PACKAGE_REPLACED the window manager is not always
+        // ready for our overlay yet
+        mHandler.postDelayed({
+            if (mCurrentProps == null) {
+                createPopup(
+                    PopupProps(
+                        duration = 10,
+                        id = UPDATE_POPUP_ID,
+                        position = PopupProps.Position.BottomRight,
+                        title = getString(R.string.update_done_title, BuildConfig.VERSION_NAME)
+                    )
+                )
+            }
+        }, 5_000)
+    }
+
     /// Show the "update available" popup at most once per version, and never over a
     /// popup that is already on screen or while the screen is off.
     private fun maybeAnnounceUpdate() {
@@ -550,10 +623,19 @@ class PiPupService : Service(), WebServer.Handler {
                 mPopup = PopupView.build(this, popup)
 
                 mPopup?.onButton = { btn ->
-                    // The app's own update popup is handled locally; it has no
-                    // callback URL and must not be mistaken for a user button.
-                    if ((mCurrentProps ?: popup).id == UPDATE_POPUP_ID) {
+                    // The app's own update popups are handled locally; they have no
+                    // callback URL and must not be mistaken for user buttons.
+                    val shownId = (mCurrentProps ?: popup).id
+                    if (shownId == UPDATE_POPUP_ID) {
+                        mHandler.post { showInstallingPopup() }
                         Thread { UpdateManager.installLatest(this) }.start()
+                    } else if (shownId == CONFIRM_POPUP_ID) {
+                        // Started from a button press = this app has a visible window,
+                        // so the system dialog launches reliably and keeps focus.
+                        UpdateManager.pendingConfirm?.let { confirm ->
+                            runCatching { startActivity(confirm) }
+                                .onFailure { Log.e(LOG_TAG, "Cannot show install prompt", it) }
+                        }
                     } else {
                         // Use the currently shown props, not this closure's `popup`:
                         // an update-in-place reuses the view but can carry a new
@@ -828,13 +910,22 @@ class PiPupService : Service(), WebServer.Handler {
                             // Self-update on request (own popup button, or the Home
                             // Assistant integration's update entity). Runs off the
                             // web-server thread; progress is visible in /state.
-                            Thread {
-                                if (!UpdateManager.updateAvailable) UpdateManager.check()
-                                if (UpdateManager.updateAvailable) {
-                                    UpdateManager.installLatest(this@PiPupService)
-                                }
-                            }.start()
-                            OK("update started")
+                            if (UpdateManager.pendingConfirm != null) {
+                                // A previous attempt is waiting for the on-screen
+                                // confirmation (Android < 12): re-offer it instead of
+                                // answering "already running".
+                                mHandler.post { showConfirmInstallPopup() }
+                                OK("waiting for on-screen confirmation; popup shown again")
+                            } else {
+                                Thread {
+                                    if (!UpdateManager.updateAvailable) UpdateManager.check()
+                                    if (UpdateManager.updateAvailable) {
+                                        mHandler.post { showInstallingPopup() }
+                                        UpdateManager.installLatest(this@PiPupService)
+                                    }
+                                }.start()
+                                OK("update started")
+                            }
                         }
                         "/power" -> powerResponse(session)
                         "/permissions/fix" -> permissionFixResponse(session)
@@ -1000,6 +1091,8 @@ class PiPupService : Service(), WebServer.Handler {
         const val PREF_DEVICE_ID = "device_id"
         const val PREF_UPDATE_ANNOUNCED = "update_announced"
         const val UPDATE_POPUP_ID = "pipup-update"
+        const val CONFIRM_POPUP_ID = "pipup-update-confirm"
+        const val PREF_LAST_RUN_VERSION = "last_run_version"
         // First check shortly after boot (network is usually up by then), then twice a day.
         // GitHub's anonymous API allows 60 requests/hour per IP; this is nowhere near it.
         const val UPDATE_CHECK_FIRST_DELAY_MS = 120_000L

--- a/app/src/main/java/nl/rogro82/pipup/UpdateManager.kt
+++ b/app/src/main/java/nl/rogro82/pipup/UpdateManager.kt
@@ -50,6 +50,23 @@ object UpdateManager {
     /// leave the flag stuck true forever - every later install answered "an update is
     /// already running" until the service restarted. Seen in the field.
     private val installStartedAt = AtomicLong(0)
+
+    /// The system's install-confirmation intent (Android < 12, or whenever the platform
+    /// insists on one). Kept so it can be re-shown: launched blind from the background
+    /// it flashes on screen and disappears (seen on a TCL, Android 11), leaving the
+    /// session waiting forever on a dialog nobody can reach. The service turns this
+    /// into a popup with a button - a press gives the app a visible window, and an
+    /// activity started from one keeps focus.
+    @Volatile var pendingConfirm: Intent? = null
+        private set
+
+    /// Set by the service; called (on a background thread) when the installer asks for
+    /// on-screen confirmation, so the service can announce it as a popup.
+    @Volatile var onPendingUserAction: (() -> Unit)? = null
+
+    fun clearPendingConfirm() {
+        pendingConfirm = null
+    }
     val isInstalling: Boolean
         get() = installStartedAt.get().let {
             it != 0L && android.os.SystemClock.elapsedRealtime() - it < INSTALL_TIMEOUT_MS
@@ -178,24 +195,30 @@ object UpdateManager {
                         PackageInstaller.EXTRA_STATUS, PackageInstaller.STATUS_FAILURE
                     )) {
                         PackageInstaller.STATUS_PENDING_USER_ACTION -> {
-                            // Pre-Android-12 (and whenever the system insists): show the
-                            // confirmation dialog on the TV. NEW_TASK because we start it
-                            // from a receiver, not an activity.
+                            // Pre-Android-12 (and whenever the system insists): the user
+                            // has to confirm on the TV. Launching the dialog blind from
+                            // this receiver made it flash and vanish (TCL, Android 11) -
+                            // so keep the intent and let the service offer it as a popup
+                            // with a button; we still try the direct launch as a bonus.
                             @Suppress("DEPRECATION")
                             val confirm = intent.getParcelableExtra<Intent>(Intent.EXTRA_INTENT)
                             confirm?.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                            pendingConfirm = confirm
                             runCatching { ctx.startActivity(confirm) }
                                 .onFailure { Log.e(LOG_TAG, "Cannot show install prompt", it) }
+                            runCatching { onPendingUserAction?.invoke() }
                             // Keep `installing` set: the flow is still in progress.
                         }
                         PackageInstaller.STATUS_SUCCESS -> {
                             Log.i(LOG_TAG, "Update installed")
+                            pendingConfirm = null
                             installStartedAt.set(0)
                         }
                         else -> {
                             val msg = intent.getStringExtra(PackageInstaller.EXTRA_STATUS_MESSAGE)
                             lastError = "install status $status: $msg"
                             Log.w(LOG_TAG, lastError!!)
+                            pendingConfirm = null
                             installStartedAt.set(0)
                         }
                     }

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -21,4 +21,9 @@
     <string name="permission_power_set">Scherm aan/uit: ingesteld (via %1$s)</string>
     <string name="permission_line_optional">%1$s: optioneel, niet ingesteld</string>
     <string name="permission_power_why">Alleen nodig als je het scherm van deze tv vanuit je domotica wilt uitzetten. Popups werken er prima zonder.</string>
+    <string name="update_installing_title">PiPup %1$s wordt geïnstalleerd…</string>
+    <string name="update_installing_message">De app herstart vanzelf als het klaar is.</string>
+    <string name="update_confirm_title">PiPup %1$s staat klaar om te installeren</string>
+    <string name="update_confirm_message">Druk op OK om de systeembevestiging te openen.</string>
+    <string name="update_done_title">PiPup bijgewerkt naar %1$s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,4 +25,9 @@
     <string name="permission_power_set">Screen on/off: configured (via %1$s)</string>
     <string name="permission_line_optional">%1$s: optional, not configured</string>
     <string name="permission_power_why">Only needed if you want to switch this TV\'s screen off from your home automation. Popups work fine without it.</string>
+    <string name="update_installing_title">Installing PiPup %1$s…</string>
+    <string name="update_installing_message">The app restarts by itself when it is done.</string>
+    <string name="update_confirm_title">PiPup %1$s is ready to install</string>
+    <string name="update_confirm_message">Press OK to open the system\'s install confirmation.</string>
+    <string name="update_done_title">PiPup updated to %1$s</string>
 </resources>


### PR DESCRIPTION
Field report: pressing **Install** in Home Assistant made "a screen flash by" on the TV, then nothing. Two platform behaviours behind it, measured on the fleet:

- **Android < 12** (TCL Google TV, 11): the installer demands an on-screen confirmation. Launched blind from the background result receiver, that dialog **flashes and vanishes** — the session then sits at `installing: true` waiting on a dialog nobody can reach. (That TV was stuck at 0.10.1 with exactly this state.)
- **Android 12+**: the install is silent and over in seconds — nothing on the TV ever acknowledged the button press, and HA's 15 s poll usually missed the whole window too (companion fix in ha-pipup 1.12.0).

## Changes

- **"Installing PiPup vX…" popup** (countdown bar) when an update starts via `POST /update` or the app's own update popup.
- **Confirmation popup with a button** when the installer wants on-screen confirmation. The kept confirm-intent is launched from the button press — a visible window of this app — so the system dialog launches reliably and keeps focus. Same background-activity-launch lesson as v0.9.0, now applied to the system installer. Repeatable: `POST /update` while a confirmation is pending re-shows the popup instead of answering *"already running"*.
- **"PiPup updated to vX" popup** after the app replaced itself (screen-on only), keyed on a last-run-version marker.

## Verified

- First-run marker behaviour on two devices: marker written, **no** false popup (by design — the marker did not exist before this version).
- Screen-off suppression on a Fire TV stick: update applied, no popup, marker set.
- The full visible flow only exists in the *new* code, so it demonstrates itself from the next update cycle onward — updating **to** 0.11.0 still runs the old silent path.
