### PR TITLE
v0.11.1: a Fix button that doesn't lie on locked-down TVs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Original app by [rogro82](https://github.com/rogro82/PiPup).
 Every version below has a [GitHub release](https://github.com/mhoogenbosch/PiPup/releases) with the
 full story (English and Dutch) and the APK.
 
+## [v0.11.1] — 2026-08-23 (a Fix button that doesn't lie on locked-down TVs)
+Field report from a TCL Smart TV Pro (Android 11): the self-update permission stayed missing no matter
+what, and the `/permissions/diagnose` output showed why — `opModes.installPackages: "errored"`.
+### Fixed
+- When an app-op is in a device-**blocked** state (`errored`/`ignored`) — some TVs lock "install
+  unknown apps" for sideloaded apps at the system level, like Samsung's Auto Blocker — the permission
+  screen opens but the toggle will not stick. The app no longer offers a Fix button that leads nowhere:
+  it shows the **adb command with a "this TV blocks it" note** instead (status screen), and
+  `POST /permissions/fix` answers **501** with that reason + command rather than opening a dead screen.
+  A neutral `default` op (the normal case) still gets the on-screen Fix button.
+
 ## [v0.11.0] — 2026-08-23 (visible updates, and a confirmation that can actually be confirmed)
 Field report: pressing Install in Home Assistant made "a screen flash by" on the TV and then nothing.
 Diagnosed on hardware: on Android < 12 the installer's confirmation dialog, launched blind from a

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "nl.rogro82.pipup"
         minSdkVersion 24
         targetSdkVersion 34
-        versionCode 30
-        versionName "0.11.0"
+        versionCode 31
+        versionName "0.11.1"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/app/src/main/java/nl/rogro82/pipup/MainActivity.kt
+++ b/app/src/main/java/nl/rogro82/pipup/MainActivity.kt
@@ -119,19 +119,30 @@ class MainActivity : Activity() {
 
         val rows = buildList {
             val overlay = Permissions.granted(this@MainActivity, Permissions.KEY_OVERLAY) == true
+            val overlayBlocked = !overlay && Permissions.opBlocked(this@MainActivity, Permissions.KEY_OVERLAY)
             add(Row(
                 getString(R.string.permission_overlay), overlay, false,
-                R.string.permission_overlay_why.takeIf { !overlay },
-                Permissions.KEY_OVERLAY.takeIf { !overlay },
+                if (overlay) null
+                else if (overlayBlocked) R.string.permission_overlay_blocked
+                else R.string.permission_overlay_why,
+                Permissions.KEY_OVERLAY.takeIf { !overlay && !overlayBlocked },
                 Permissions.adbCommand(Permissions.KEY_OVERLAY).takeIf { !overlay }
             ))
             val install = Permissions.granted(this@MainActivity, Permissions.KEY_INSTALL) == true
-            if (!install) add(Row(
-                getString(R.string.permission_install), false, false,
-                R.string.permission_install_why,
-                Permissions.KEY_INSTALL,
-                Permissions.adbCommand(Permissions.KEY_INSTALL)
-            ))
+            if (!install) {
+                // A device-blocked op (errored/ignored, e.g. TCL) has a settings screen
+                // that will not stick, so drop the Fix button and show only the adb
+                // command with a "device blocks this" explanation.
+                val installBlocked = Permissions.opBlocked(this@MainActivity, Permissions.KEY_INSTALL)
+                add(Row(
+                    getString(R.string.permission_install),
+                    false, false,
+                    if (installBlocked) R.string.permission_install_blocked
+                    else R.string.permission_install_why,
+                    Permissions.KEY_INSTALL.takeIf { !installBlocked },
+                    Permissions.adbCommand(Permissions.KEY_INSTALL)
+                ))
+            }
             val method = PowerController.sleepMethod(this@MainActivity)
             if (method != null) {
                 add(Row(getString(R.string.permission_power_set, method), true, true, null, null, null))

--- a/app/src/main/java/nl/rogro82/pipup/Permissions.kt
+++ b/app/src/main/java/nl/rogro82/pipup/Permissions.kt
@@ -191,7 +191,30 @@ object Permissions {
     ///   filtered by package visibility on Android 11+, while `startActivity()` is not - so
     ///   "I cannot see it" does not mean "it is not there". Refusing here would hide a
     ///   working button on any device whose forceQueryable list omits Settings.
+    /// The underlying app-op name for a key, or null for keys that are not app-ops
+    /// (device admin, accessibility - those are not appops-gated).
+    private fun opFor(key: String): String? = when (key) {
+        KEY_OVERLAY -> "android:system_alert_window"
+        KEY_INSTALL -> "android:request_install_packages"
+        else -> null
+    }
+
+    /// True when the device has put this permission's app-op into an explicitly denied
+    /// state (`errored` or `ignored`), as opposed to the neutral `default`. Measured on a
+    /// TCL Smart TV Pro (Android 11): REQUEST_INSTALL_PACKAGES sat at `errored`, the
+    /// settings screen opened but the toggle would not stick, and only adb could change
+    /// it. So when this is true, sending the user to the screen is a dead end - the honest
+    /// answer is the adb command.
+    fun opBlocked(context: Context, key: String): Boolean {
+        val op = opFor(key) ?: return false
+        return opMode(context, op) in setOf("errored", "ignored")
+    }
+
     fun fixIntent(context: Context, key: String): Intent? {
+        // A device-blocked op cannot be granted from the settings screen (verified on
+        // TCL: the screen opens, the toggle does not stick), so do not offer a button
+        // that leads nowhere - callers fall back to showing the adb command.
+        if (opBlocked(context, key)) return null
         val intent = rawIntent(context, key) ?: return null
         return if (isPlaceholder(resolvedActivity(context, intent))) null else intent
     }

--- a/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
@@ -831,6 +831,11 @@ class PiPupService : Service(), WebServer.Handler {
         // device cannot show that screen" is the worst of both worlds - seen for real
         // when a failing request from Home Assistant still lit up a TV in another room.
         val refusal: String? = when {
+            // Device-blocked app-op (errored/ignored): the settings screen exists but the
+            // toggle will not stick (seen on a TCL Smart TV Pro), so adb is the only way.
+            key != null && Permissions.opBlocked(this, key) ->
+                "this device blocks granting this permission from its settings screen; " +
+                    "grant it over adb instead"
             key != null && Permissions.fixIntent(this, key) == null ->
                 "no screen for this permission on this device"
             // Silently dropped by the platform otherwise - see Permissions.canLaunchActivity

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -26,4 +26,6 @@
     <string name="update_confirm_title">PiPup %1$s staat klaar om te installeren</string>
     <string name="update_confirm_message">Druk op OK om de systeembevestiging te openen.</string>
     <string name="update_done_title">PiPup bijgewerkt naar %1$s</string>
+    <string name="permission_install_blocked">Deze tv blokkeert het aanzetten via het instellingenscherm. Ken het toe via adb:</string>
+    <string name="permission_overlay_blocked">Deze tv blokkeert het aanzetten via het instellingenscherm. Ken het toe via adb:</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,4 +30,6 @@
     <string name="update_confirm_title">PiPup %1$s is ready to install</string>
     <string name="update_confirm_message">Press OK to open the system\'s install confirmation.</string>
     <string name="update_done_title">PiPup updated to %1$s</string>
+    <string name="permission_install_blocked">This TV blocks turning it on from its settings screen. Grant it over adb:</string>
+    <string name="permission_overlay_blocked">This TV blocks turning it on from its settings screen. Grant it over adb:</string>
 </resources>


### PR DESCRIPTION
Follow-up to a field report (TCL Smart TV Pro, Android 11): the self-update permission stayed `MISSING` no matter how often the user pressed Fix. The `/permissions/diagnose` we added in 0.10.2 showed exactly why:

```
"opModes": { "installPackages": "errored", "overlay": "allowed" }
"lastFix": { "what": "install", "ok": true, ... }   ← screen opened, toggle didn't stick
```

`errored` is a **device-blocked** app-op — several OEMs lock "install unknown apps" for sideloaded apps at the system level (Samsung's Auto Blocker is the well-known one). The settings screen opens, but the switch won't take; only adb can change it.

## Change

When an app-op is `errored`/`ignored`, PiPup stops pretending the on-screen route works:

- **Status screen**: the missing permission shows the **adb command + "this TV blocks it from its settings screen"** instead of a Fix button.
- **`POST /permissions/fix`**: answers **501** with that reason and the adb command, instead of opening a screen that changes nothing.
- A neutral `default` op (the normal case) keeps the on-screen Fix button — unchanged.

## Verified on hardware (TCL, Atelier)

Forced the install-op to `ignored`: `/permissions/diagnose` → `install.fixable: false`; `POST /permissions/fix?what=install` → `501` with `reason` + adb command; status screen shows the adb line under "Self-update: MISSING" (screenshot). Restored to `allow` → button/behaviour back to normal.

Companion: ha-pipup v1.13.0 adds a **"Fix self-update permission"** button that surfaces the same 501+adb message in Home Assistant.
