### PR TITLE
Start on a silent power-restore boot (directBoot + LOCKED_BOOT_COMPLETED)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ Original app by [rogro82](https://github.com/rogro82/PiPup).
 Every version below has a [GitHub release](https://github.com/mhoogenbosch/PiPup/releases) with the
 full story (English and Dutch) and the APK.
 
+## [v0.12.0] — 2026-08-24 (comes back after a silent power-cut boot)
+Field report: after a mains power cut and restore, if the TV boots to standby without being turned on
+and is later woken over ADB, PiPup never starts — the connectivity sensor stays offline until the app
+is opened by hand from the app drawer.
+### Fixed
+- **Root cause:** `BOOT_COMPLETED` — which the app already listens for to restart itself — is only
+  broadcast once the device reaches a fully started, unlocked user session. A TV that boots to standby
+  after a power restore never reaches that point, and waking it over ADB does not re-fire the boot
+  broadcast, so the service stayed down.
+- The boot receiver **and** the service are now `directBootAware` and also listen for
+  **`LOCKED_BOOT_COMPLETED`** (plus `QUICKBOOT_POWERON` for OEM fast-boot). These fire in the early
+  locked-boot phase, before turn-on, so the service starts on a silent power-restore boot too.
+- App preferences (the stable device id and version markers — none of them sensitive) moved to
+  **device-protected storage** so they are readable during direct boot; the existing file is migrated
+  once, so the device id — and therefore the Home Assistant unique_id — stays the same.
+
 ## [v0.11.1] — 2026-08-23 (a Fix button that doesn't lie on locked-down TVs)
 Field report from a TCL Smart TV Pro (Android 11): the self-update permission stayed missing no matter
 what, and the `/permissions/diagnose` output showed why — `opModes.installPackages: "errored"`.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "nl.rogro82.pipup"
         minSdkVersion 24
         targetSdkVersion 34
-        versionCode 31
-        versionName "0.11.1"
+        versionCode 32
+        versionName "0.12.0"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -56,13 +56,26 @@
         <receiver
                 android:name=".Receiver"
                 android:enabled="true"
-                android:exported="true">
+                android:exported="true"
+                android:directBootAware="true">
             <!-- CONNECTIVITY_CHANGE / WIFI_STATE_CHANGED used to be here too, but
                  Android has not delivered those implicit broadcasts to manifest
                  receivers since API 24/26 - with minSdk 24 they were dead filters
                  that only suggested a start-on-network-change that never happens. -->
+            <!-- BOOT_COMPLETED is only broadcast once the device reaches a fully
+                 started, unlocked user session. A TV whose mains power is restored
+                 but which is not turned on parks in standby and never reaches that
+                 point, so the service would stay down until the app was opened by
+                 hand (reported in the field). directBootAware + LOCKED_BOOT_COMPLETED
+                 fire in the early locked-boot phase instead, well before turn-on;
+                 the service reads no credential-protected storage at start, so
+                 device-protected storage is enough. QUICKBOOT_POWERON covers OEMs
+                 (some HTC/Xiaomi builds) that fast-boot without a normal BOOT_COMPLETED. -->
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED" />
+                <action android:name="android.intent.action.QUICKBOOT_POWERON" />
+                <action android:name="com.htc.intent.action.QUICKBOOT_POWERON" />
             </intent-filter>
             <!-- Sent to this app after its own APK is replaced (self-update, or
                  `adb install -r`). Without it the service stays down after every
@@ -77,6 +90,7 @@
                 android:name=".PiPupService"
                 android:enabled="true"
                 android:exported="true"
+                android:directBootAware="true"
                 android:foregroundServiceType="specialUse">
             <property
                     android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"

--- a/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
@@ -187,9 +187,28 @@ class PiPupService : Service(), WebServer.Handler {
         }
     }
 
+    /// App preferences, kept in *device-protected* storage. The service can start
+    /// during direct boot (LOCKED_BOOT_COMPLETED, before first unlock) on a TV whose
+    /// mains power was restored, and credential-protected prefs are unreadable then.
+    /// None of the keys here are sensitive (device id, version markers). Existing
+    /// installs kept them in the default credential-protected file; move it once so
+    /// the device id — and therefore the Home Assistant unique_id — stays stable.
+    private fun prefs(): android.content.SharedPreferences {
+        val ctx = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+            applicationContext.createDeviceProtectedStorageContext() else applicationContext
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
+            !ctx.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).contains(PREF_DEVICE_ID)) {
+            // one-time migration from the old location; a no-op once moved, and safe
+            // to skip while credential storage is still locked (the id is regenerated
+            // only if neither file has it, which cannot happen for an existing install)
+            runCatching { ctx.moveSharedPreferencesFrom(applicationContext, PREFS_NAME) }
+        }
+        return ctx.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    }
+
     /// stable device identifier: generated once, survives app updates (not reinstalls)
     private fun deviceId(): String {
-        val prefs = getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val prefs = prefs()
         return prefs.getString(PREF_DEVICE_ID, null) ?: UUID.randomUUID().toString().also {
             prefs.edit().putString(PREF_DEVICE_ID, it).apply()
         }
@@ -480,7 +499,7 @@ class PiPupService : Service(), WebServer.Handler {
     /// happened silently (Android 12+) is still visibly acknowledged. Only when the
     /// screen is on; the version marker is bumped regardless, so it never shows stale.
     private fun maybeAnnounceInstalledUpdate() {
-        val prefs = getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val prefs = prefs()
         val previous = prefs.getString(PREF_LAST_RUN_VERSION, null)
         prefs.edit().putString(PREF_LAST_RUN_VERSION, BuildConfig.VERSION_NAME).apply()
         if (previous == null || previous == BuildConfig.VERSION_NAME) return
@@ -507,7 +526,7 @@ class PiPupService : Service(), WebServer.Handler {
     /// popup that is already on screen or while the screen is off.
     private fun maybeAnnounceUpdate() {
         val version = UpdateManager.latestVersion ?: return
-        val prefs = getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val prefs = prefs()
         if (prefs.getString(PREF_UPDATE_ANNOUNCED, null) == version) return
 
         val power = getSystemService(Context.POWER_SERVICE) as PowerManager

--- a/app/src/main/java/nl/rogro82/pipup/Receiver.kt
+++ b/app/src/main/java/nl/rogro82/pipup/Receiver.kt
@@ -12,17 +12,29 @@ import androidx.core.content.ContextCompat.startForegroundService
 /// MY_PACKAGE_REPLACED nothing brings the service back — the TV would silently drop
 /// off until the next reboot. (Network-change broadcasts are no longer delivered to
 /// manifest receivers on any supported Android, so there is no filter for them.)
+///
+/// Boot: BOOT_COMPLETED is only broadcast once the device reaches an unlocked user
+/// session, which a TV that boots to standby after a mains-power restore may never
+/// do until it is turned on. Both this receiver and the service are directBootAware
+/// and also listen for LOCKED_BOOT_COMPLETED, so the service starts in the early
+/// locked-boot phase — before turn-on — instead (reported in the field: the app
+/// never came up after a power cut until it was opened by hand).
 class Receiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
         Log.d("PiPupReceiver", "Starting service after ${intent.action}")
-        with(context) {
-            val serviceIntent = Intent(this, PiPupService::class.java)
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                startForegroundService(serviceIntent)
-            } else {
-                startService(serviceIntent)
+        // A stray throw here (e.g. a foreground-service start the platform briefly
+        // refuses during locked boot) must not crash the receiver; BOOT_COMPLETED
+        // would still follow on unlock.
+        runCatching {
+            with(context) {
+                val serviceIntent = Intent(this, PiPupService::class.java)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    startForegroundService(serviceIntent)
+                } else {
+                    startService(serviceIntent)
+                }
             }
-        }
+        }.onFailure { Log.w("PiPupReceiver", "Service start failed: ${it.message}") }
     }
 }


### PR DESCRIPTION
## Problem
Reported on the forum (Ltek): after a mains power cut and restore, if the TV boots to standby without being turned on and is later woken over ADB, PiPup never starts — `binary_sensor.*_connectivity` stays offline until the APK is opened by hand from the app drawer. The keep-alive automation does not rescue it.

## Root cause
`BOOT_COMPLETED` — which the boot receiver already listens for — is only broadcast once the device reaches a fully started, **unlocked** user session. A TV that boots to standby after a power restore never reaches that point, and waking it over ADB is a wake event, not a boot event, so the one-shot broadcast never fires.

## Fix
- Receiver **and** service `directBootAware`, and also listen for **`LOCKED_BOOT_COMPLETED`** (+ `QUICKBOOT_POWERON` / HTC variant). These fire in the early locked-boot phase, before turn-on.
- App prefs (device id + version markers — nothing sensitive) move to **device-protected storage** so they are readable during direct boot; the existing file is migrated once so the device id (and thus the HA unique_id) stays stable.
- `runCatching` guard around the boot-time service start.

## Verified on hardware (Fire TV, Android 9)
- Device id **unchanged** across the update (`d8f98bb6…`), version → 0.12.0 — prefs migration preserved it.
- Force-stop → explicit broadcast to `.Receiver` brought the HTTP server back up (receiver→service wiring).
- **Reboot with the remote untouched → service self-started 27s later, uptime 1s.**

`LOCKED_BOOT_COMPLETED` is a protected broadcast (system-only), so the exact standby-boot delivery can only be reproduced on a real mains-cut; the self-start after reboot confirms the boot path works on Fire OS.
