### PR TITLE
Wake the TV for a pending install confirmation; release stalled installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ Original app by [rogro82](https://github.com/rogro82/PiPup).
 Every version below has a [GitHub release](https://github.com/mhoogenbosch/PiPup/releases) with the
 full story (English and Dutch) and the APK.
 
+## [v0.12.1] — 2026-08-24 (a remote-initiated update no longer stalls invisibly)
+Field report: pressing Install in Home Assistant for a sleeping Fire TV (Android 9) did nothing visible,
+and afterwards it only said an update was already running.
+### Fixed
+- Android < 12 cannot install without an on-screen confirmation (the install permission does not change
+  that). The app already turns that into a popup with a button, but it did **not wake the screen** — so
+  on a sleeping TV the confirmation sat on a black screen and the update stalled invisibly. The app now
+  **wakes the screen** when a confirmation is pending, so one remote press finishes it.
+- The stalled state (`installing: true`) used to linger for 15 minutes after an unconfirmed attempt. The
+  pending install is now **released as soon as its confirmation popup goes away** unconfirmed, so the
+  update can be retried immediately.
+- `/state.update` gained **`pendingUserAction`** (waiting for the on-screen confirmation) and **`silent`**
+  (false on Android < 12, where an install cannot complete without a remote press), so a controller can
+  say "confirm on the TV" instead of a bare "installing".
+
 ## [v0.12.0] — 2026-08-24 (comes back after a silent power-cut boot)
 Field report: after a mains power cut and restore, if the TV boots to standby without being turned on
 and is later woken over ADB, PiPup never starts — the connectivity sensor stays offline until the app

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "nl.rogro82.pipup"
         minSdkVersion 24
         targetSdkVersion 34
-        versionCode 32
-        versionName "0.12.0"
+        versionCode 33
+        versionName "0.12.1"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
@@ -381,12 +381,21 @@ class PiPupService : Service(), WebServer.Handler {
         notificationManager.createNotificationChannel(channel)
     }
 
-    private fun removePopup(removeOverlay: Boolean = false) {
+    private fun removePopup(removeOverlay: Boolean = false, byButton: Boolean = false) {
 
         mHandler.removeCallbacksAndMessages(null)
 
+        val removed = mCurrentProps
         mCurrentProps = null
         mShownAt = 0L
+
+        // The install-confirmation popup (Android < 12) going away without its button
+        // being pressed - it expired, or another popup replaced it - means the user
+        // never confirmed. Release the pending state so /state stops reporting an
+        // install in progress for 15 minutes and the update can be retried.
+        if (!byButton && removed?.id == CONFIRM_POPUP_ID && UpdateManager.pendingUserAction) {
+            UpdateManager.abandonPending()
+        }
 
         // every step guarded: a throwing WebView/VideoView teardown or WindowManager call
         // used to abort the removal halfway, leaving the popup visible on screen while the
@@ -481,6 +490,10 @@ class PiPupService : Service(), WebServer.Handler {
     /// it again instead of answering "already running".
     private fun showConfirmInstallPopup() {
         val version = UpdateManager.latestVersion ?: return
+        // Wake the screen: the confirmation is worthless on a sleeping TV (the system
+        // dialog and this popup would sit on a black screen), and a remote-initiated
+        // update from Home Assistant otherwise stalls invisibly. Field-reported.
+        PowerController.wake(this)
         createPopup(
             PopupProps(
                 duration = 120,
@@ -661,7 +674,9 @@ class PiPupService : Service(), WebServer.Handler {
                         // callback URL, so the captured value would be stale.
                         sendButtonCallback(mCurrentProps ?: popup, btn)
                     }
-                    mHandler.post { removePopup(true) }
+                    // byButton: a confirm-popup dismissed by its own button must keep the
+                    // pending install alive (the system dialog was just launched).
+                    mHandler.post { removePopup(removeOverlay = true, byButton = true) }
                 }
 
                 it.addView(mPopup, FrameLayout.LayoutParams(
@@ -740,6 +755,10 @@ class PiPupService : Service(), WebServer.Handler {
             "available" to UpdateManager.updateAvailable,
             "latest" to UpdateManager.latestVersion,
             "installing" to UpdateManager.isInstalling,
+            // waiting for the on-screen confirmation Android < 12 always demands
+            "pendingUserAction" to UpdateManager.pendingUserAction,
+            // false on Android < 12: an install cannot complete without a remote press
+            "silent" to UpdateManager.silentInstall,
             "checkedSecondsAgo" to UpdateManager.lastCheckedAt.takeIf { it > 0 }
                 ?.let { (System.currentTimeMillis() - it) / 1000 },
             "error" to UpdateManager.lastError

--- a/app/src/main/java/nl/rogro82/pipup/UpdateManager.kt
+++ b/app/src/main/java/nl/rogro82/pipup/UpdateManager.kt
@@ -67,6 +67,24 @@ object UpdateManager {
     fun clearPendingConfirm() {
         pendingConfirm = null
     }
+
+    /// True while an install is waiting for the on-screen confirmation the platform
+    /// demands on Android < 12 — distinct from actively installing, so a controller
+    /// can say "confirm on the TV" instead of a bare "installing" or "already running".
+    val pendingUserAction: Boolean
+        get() = pendingConfirm != null
+
+    /// Whether a self-update can run without an on-screen confirmation (Android 12+).
+    val silentInstall: Boolean
+        get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+
+    /// Give up a stalled attempt (its confirmation popup expired unconfirmed), so
+    /// /state stops reporting an install in progress and the update can be retried.
+    fun abandonPending() {
+        pendingConfirm = null
+        installStartedAt.set(0)
+    }
+
     val isInstalling: Boolean
         get() = installStartedAt.get().let {
             it != 0L && android.os.SystemClock.elapsedRealtime() - it < INSTALL_TIMEOUT_MS


### PR DESCRIPTION
## Problem
Reported: pressing Install in Home Assistant for a sleeping Fire TV (Android 9) did nothing visible, then only said an update was already running.

## Cause
Android < 12 always needs an on-screen install confirmation (the `REQUEST_INSTALL_PACKAGES` app-op does not change that — `PackageInstaller` returns `PENDING_USER_ACTION`). The app turns that into a popup with a button, but did **not wake the screen** — so on a sleeping TV both the system dialog and the popup sat on a black screen, and the update stalled invisibly. `installing: true` then lingered for 15 min, so HA reported "already running".

## Fix
- Wake the screen (`PowerController.wake`) when a confirmation is pending, so one remote press finishes it.
- Release the pending install as soon as its confirmation popup goes away unconfirmed (`removePopup(byButton=false)` on the confirm popup → `UpdateManager.abandonPending()`), instead of keeping `installing:true` for 15 min.
- `/state.update`: add `pendingUserAction` and `silent` (false on Android < 12) so a controller can say "confirm on the TV".

## Verified
- Compiles; `PowerController.wake` (the one new runtime call in the confirm path) confirmed Asleep→Awake on a Fire TV via the same code path (`/power?state=on`).
- Full confirm-on-sleep end-to-end was **not** reproduced on hardware: it needs installed<latest, which a Fire TV only allows via an uninstall, and that wipes the stable device id (the HA unique_id). The wake primitive and the confirm popup itself (unchanged since 0.11.0) are both already field-proven.
