### PR TITLE
Visible focus highlight on multi-button popups (#18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Original app by [rogro82](https://github.com/rogro82/PiPup).
 Every version below has a [GitHub release](https://github.com/mhoogenbosch/PiPup/releases) with the
 full story (English and Dutch) and the APK.
 
+## [v0.12.2] — 2026-08-24 (visible focus on multi-button popups)
+Reported (#18): on a popup with multiple buttons, D-pad navigation worked — the correct button fired —
+but nothing on screen showed which button was focused, so it looked unresponsive.
+### Fixed
+- In an overlay window the platform button background carries no focus state, so moving focus with the
+  remote was invisible. Each button now has an explicit **focused/unfocused background** (a bright fill
+  when focused, a subtle translucent one otherwise) plus a small **scale bump** on focus, and the first
+  button takes focus when the popup appears — so there is a highlight from the start.
+
 ## [v0.12.1] — 2026-08-24 (a remote-initiated update no longer stalls invisibly)
 Field report: pressing Install in Home Assistant for a sleeping Fire TV (Android 9) did nothing visible,
 and afterwards it only said an update was already running.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "nl.rogro82.pipup"
         minSdkVersion 24
         targetSdkVersion 34
-        versionCode 33
-        versionName "0.12.1"
+        versionCode 34
+        versionName "0.12.2"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/app/src/main/java/nl/rogro82/pipup/PopupView.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PopupView.kt
@@ -5,6 +5,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Color
 import android.graphics.drawable.GradientDrawable
+import android.graphics.drawable.StateListDrawable
 import android.net.Uri
 import android.util.Log
 import android.view.Gravity
@@ -86,22 +87,43 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
                 ?: if (width != null && width > 0) PopupProps.DEFAULT_CORNER_RADIUS else 0f
         }
 
-        // DPAD-focusable buttons (the service makes the overlay window focusable)
+        // DPAD-focusable buttons (the service makes the overlay window focusable).
+        // In an overlay window the platform button background carries no visible
+        // focus state, so D-pad navigation moved focus invisibly - the user pressed
+        // the arrows, saw nothing change and concluded the popup was not interactive
+        // (reported for a 3-button popup on a Shield). Each button gets an explicit
+        // focused/unfocused background plus a small scale bump on focus, and the
+        // first one takes focus so there is an indicator from the start.
         if (popup.buttons.isNotEmpty()) {
             val row = LinearLayout(context).apply {
                 orientation = HORIZONTAL
                 gravity = Gravity.CENTER
             }
+            var firstButton: Button? = null
             popup.buttons.forEach { btn ->
-                row.addView(Button(context).apply {
+                val button = Button(context).apply {
                     text = btn.label
                     isFocusable = true
+                    isAllCaps = false
+                    setTextColor(Color.WHITE)
+                    setPadding(36, 16, 36, 16)
+                    stateListAnimator = null   // the platform one would fight our scale
+                    background = buttonBackground()
                     setOnClickListener { onButton?.invoke(btn) }
-                }, LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT).apply {
+                    setOnFocusChangeListener { v, hasFocus ->
+                        val s = if (hasFocus) 1.12f else 1f
+                        v.animate().scaleX(s).scaleY(s).setDuration(120).start()
+                    }
+                }
+                if (firstButton == null) firstButton = button
+                row.addView(button, LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT).apply {
                     setMargins(10, 10, 10, 0)
                 })
             }
             addView(row, LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT))
+            // Give the first button focus once the view is attached, so there is a
+            // visible highlight before the user touches the remote.
+            firstButton?.post { firstButton?.requestFocus() }
         }
 
         // countdown bar for finite durations
@@ -297,6 +319,28 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
 
     companion object {
         const val LOG_TAG = "PopupView"
+
+        /// Bright fill shown on the focused popup button. White text stays readable on it.
+        val DEFAULT_BUTTON_FOCUS_COLOR = Color.parseColor("#2979FF")
+
+        /// Focus-aware button background: a bright fill when focused, a subtle
+        /// translucent one otherwise — so D-pad navigation is visible in an overlay
+        /// window, where the platform button carries no focus state of its own.
+        fun buttonBackground(): StateListDrawable {
+            fun pill(fill: Int, stroke: Int) = GradientDrawable().apply {
+                shape = GradientDrawable.RECTANGLE
+                cornerRadius = 12f
+                setColor(fill)
+                setStroke(2, stroke)
+            }
+            val focused = pill(DEFAULT_BUTTON_FOCUS_COLOR, Color.WHITE)
+            val normal = pill(Color.parseColor("#33FFFFFF"), Color.parseColor("#66FFFFFF"))
+            return StateListDrawable().apply {
+                addState(intArrayOf(android.R.attr.state_focused), focused)
+                addState(intArrayOf(android.R.attr.state_pressed), focused)
+                addState(intArrayOf(), normal)
+            }
+        }
 
         /// A malformed color must never take the whole popup down: an unparseable
         /// value falls back instead of throwing out of create().


### PR DESCRIPTION
Fixes #18.

## Problem
On a multi-button popup, D-pad navigation worked (the correct button fired) but there was **no visible focus indicator**, so the user couldn't tell which button was selected — it looked unresponsive.

## Cause
The buttons are plain `Button`s in an overlay window, where the platform button background carries no focus state, so moving focus with the remote was invisible.

## Fix
- Each button gets an explicit **focused/unfocused background** (`StateListDrawable`: a bright fill when focused, a subtle translucent one otherwise) plus a small **scale bump** on focus.
- The **first button takes focus** when the popup appears, so there is a highlight from the start.

## Verified on hardware (Fire TV)
Popup with 3 buttons: `mCurrentFocus` is the PiPup overlay, initial focus lands on the first button, `DPAD_RIGHT` moves focus, and `OK` activates the focused button (`Button b pressed` after RIGHT+OK). No regression in navigation or dismissal.

App-only; no integration change. A per-call `buttonFocusColor` could be added later if a caller wants to theme the highlight — the default is a clear blue.
