### PR TITLE
Add an optional icon beside the title and message (#19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Original app by [rogro82](https://github.com/rogro82/PiPup).
 Every version below has a [GitHub release](https://github.com/mhoogenbosch/PiPup/releases) with the
 full story (English and Dutch) and the APK.
 
+## [v0.13.0] — 2026-08-25 (an icon beside the title and message)
+Requested (#19): show an icon next to the popup's title/message, notification-style.
+### Added
+- Optional **`icon`** field (an image URL, loaded like other media) shown beside the title/message block,
+  with **`iconPosition`** `left` (default) or `right` and **`iconWidth`** (pixels, default 96). Available
+  on both the JSON and multipart `/notify` endpoints. The text now sits in a column next to the icon; the
+  media image stays below, and a media-only popup drops the empty header row.
+
 ## [v0.12.2] — 2026-08-24 (visible focus on multi-button popups)
 Reported (#18): on a popup with multiple buttons, D-pad navigation worked — the correct button fired —
 but nothing on screen showed which button was focused, so it looked unresponsive.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "nl.rogro82.pipup"
         minSdkVersion 24
         targetSdkVersion 34
-        versionCode 34
-        versionName "0.12.2"
+        versionCode 35
+        versionName "0.13.0"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
@@ -1091,6 +1091,10 @@ class PiPupService : Service(), WebServer.Handler {
                                             messageSize = messageSize,
                                             messageColor = messageColor,
                                             media = media,
+                                            icon = params["icon"],
+                                            iconPosition = params["iconPosition"],
+                                            iconWidth = params["iconWidth"]?.toIntOrNull()
+                                                ?: PopupProps.DEFAULT_ICON_WIDTH,
                                             tts = params["tts"],
                                             ttsLanguage = params["ttsLanguage"],
                                             // styling also applies to uploaded snapshots

--- a/app/src/main/java/nl/rogro82/pipup/PopupProps.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PopupProps.kt
@@ -17,6 +17,10 @@ data class PopupProps(
     val messageSize: Float = DEFAULT_MESSAGE_SIZE,
     val messageColor: String = DEFAULT_MESSAGE_COLOR,
     val media: Media? = null,
+    // Optional icon shown beside the title/message block (image URL, loaded like media).
+    val icon: String? = null,
+    val iconPosition: String? = null,     // "left" (default) or "right"
+    val iconWidth: Int = DEFAULT_ICON_WIDTH, // pixels
     val tts: String? = null,              // optional text spoken on the device when the popup is (re)shown
     val ttsLanguage: String? = null,      // optional BCP-47 tag (e.g. "nl-NL"); device default when omitted
     val urgency: String? = null,          // info | warning | critical: colored border preset
@@ -78,6 +82,7 @@ data class PopupProps(
         const val DEFAULT_MESSAGE_SIZE = 12f
         const val DEFAULT_MESSAGE_COLOR = "#ffffff"
         const val DEFAULT_MEDIA_WIDTH = 480
+        const val DEFAULT_ICON_WIDTH = 96           // px; icon beside the title/message
         const val DEFAULT_BORDER_WIDTH = 4          // a borderColor without a borderWidth
         const val DEFAULT_BORDER_COLOR = "#ffffff"  // a borderWidth without a borderColor
         const val DEFAULT_CORNER_RADIUS = 8f        // whenever a border is drawn

--- a/app/src/main/java/nl/rogro82/pipup/PopupView.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PopupView.kt
@@ -46,13 +46,15 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
         val title = findViewById<TextView>(R.id.popup_title)
         val message = findViewById<TextView>(R.id.popup_message)
         val frame = findViewById<FrameLayout>(R.id.popup_frame)
+        val header = findViewById<LinearLayout>(R.id.popup_header)
+        val textcol = findViewById<LinearLayout>(R.id.popup_textcol)
 
         if(popup.media == null) {
             removeView(frame)
         }
 
         if(popup.title.isNullOrEmpty()) {
-            removeView(title)
+            textcol.removeView(title)
         } else {
             title.text = popup.title
             title.textSize = popup.titleSize
@@ -60,11 +62,34 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
         }
 
         if(popup.message.isNullOrEmpty()) {
-            removeView(message)
+            textcol.removeView(message)
         } else {
             message.text = popup.message
             message.textSize = popup.messageSize
             message.setTextColor(parseColorOrDefault(popup.messageColor, PopupProps.DEFAULT_MESSAGE_COLOR))
+        }
+
+        // Optional icon beside the text block, left (default) or right. Loaded like
+        // any other image; adjustViewBounds keeps its aspect ratio at the given width.
+        if (!popup.icon.isNullOrEmpty()) {
+            val onRight = popup.iconPosition.equals("right", ignoreCase = true)
+            val iconView = findViewById<ImageView>(
+                if (onRight) R.id.popup_icon_right else R.id.popup_icon_left
+            )
+            iconView.layoutParams = (iconView.layoutParams as LinearLayout.LayoutParams).apply {
+                width = popup.iconWidth
+                height = LayoutParams.WRAP_CONTENT
+            }
+            iconView.visibility = View.VISIBLE
+            // override(): the view's height is WRAP_CONTENT, which Glide would otherwise
+            // decode at screen size; bound it to the icon width (adjustViewBounds keeps
+            // the aspect ratio on display).
+            Glide.with(context).load(popup.icon).override(popup.iconWidth).into(iconView)
+        }
+
+        // Nothing left in the header (media-only popup) -> drop the empty row.
+        if (textcol.childCount == 0 && popup.icon.isNullOrEmpty()) {
+            removeView(header)
         }
 
         // background with an optional border: `urgency` is a shorthand for a

--- a/app/src/main/res/layout/popup.xml
+++ b/app/src/main/res/layout/popup.xml
@@ -7,15 +7,52 @@
             android:paddingBottom="3dp"
             android:paddingTop="3dp">
     </FrameLayout>
-    <TextView
+
+    <!-- Title/message with an optional icon beside them (left or right).
+         Both ImageViews are gone until an icon URL is supplied. -->
+    <LinearLayout
+            android:id="@+id/popup_header"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:id="@+id/popup_title"
-            android:textSize="30sp"
-            android:textStyle="bold"/>
-    <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:id="@+id/popup_message" android:textSize="24sp"
-    />
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+
+        <ImageView
+                android:id="@+id/popup_icon_left"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="12dp"
+                android:adjustViewBounds="true"
+                android:visibility="gone"
+                android:contentDescription="@null"/>
+
+        <LinearLayout
+                android:id="@+id/popup_textcol"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+            <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:id="@+id/popup_title"
+                    android:textSize="30sp"
+                    android:textStyle="bold"/>
+            <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:id="@+id/popup_message" android:textSize="24sp"
+            />
+        </LinearLayout>
+
+        <ImageView
+                android:id="@+id/popup_icon_right"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="12dp"
+                android:adjustViewBounds="true"
+                android:visibility="gone"
+                android:contentDescription="@null"/>
+    </LinearLayout>
 </merge>

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,8 @@ streams) on your TV from your home-automation system, for **as long as you want*
   popup frame yourself; each field overrides its part of the `urgency` preset, so the preset stays a
   shorthand and `borderWidth: 0` switches its border off again. Also available on uploaded snapshots
   (multipart), which previously ignored `urgency` and `showProgress` entirely.
+- **Icon beside the text** (since 0.13.0) — an optional `icon` (image URL) shown next to the
+  title/message, notification-style, with `iconPosition` (`left`/`right`) and `iconWidth`.
 - **Screen on/off** (since 0.7.0) — `POST /power?state=on|off|toggle` wakes the TV or puts it in
   standby, without a second integration for ADB or HDMI-CEC. `/state` publishes what is actually
   possible on this device (`power.canSleep`, `power.sleepMethod`) instead of accepting a request it
@@ -336,6 +338,20 @@ corners on a plain popup. Sizes are in **pixels**, like every other dimension in
 width, padding) — on a 1080p TV a border of 10 is comfortably visible. An unparseable color falls
 back to the default instead of dropping the popup.
 
+Since 0.13.0 an icon can be shown beside the title/message (notification-style):
+
+```json
+{
+  "icon": "http://your-ha:8123/local/icons/doorbell.png",
+  "iconPosition": "left",
+  "iconWidth": 96
+}
+```
+
+`icon` is an image URL, loaded like the other media. `iconPosition` is `left` (default) or `right`;
+`iconWidth` is in pixels (default 96, aspect ratio preserved). The title and message sit in a column
+next to the icon, and the `media` image (if any) stays below.
+
 - `duration`: seconds to show the popup. **`0` or negative shows it indefinitely**, until `/cancel`
   is called or a new popup replaces it.
 - `id` (string, optional): identifies the popup. Re-sending a notify with the same `id` and identical
@@ -372,6 +388,9 @@ Form-fields:
 | borderColor     | String (format=[AA]RRGGBB, since 0.7.0)      |
 | borderWidth     | Integer pixels (since 0.7.0)                 |
 | cornerRadius    | Number pixels (since 0.7.0)                  |
+| icon            | String image URL (since 0.13.0)              |
+| iconPosition    | String left/right (default=left, since 0.13.0) |
+| iconWidth       | Integer pixels (default=96, since 0.13.0)    |
 | showProgress    | Boolean (default=false, since 0.7.0)         |
 
 `position` is an enum ranging from 0 to 4:


### PR DESCRIPTION
Closes #19.

Adds an optional **`icon`** (image URL, loaded via Glide) shown beside the title/message block, notification-style — as in the requester's mockup.

- **`iconPosition`**: `left` (default) or `right`.
- **`iconWidth`**: pixels (default 96), aspect ratio preserved (`adjustViewBounds` + bounded Glide decode).
- Parsed on both the JSON and multipart `/notify` endpoints.
- Layout: title + message move into a column beside the icon; the `media` image stays below. A media-only popup drops the now-empty header row.

## Verified on hardware (Fire TV)
Popup renders with the icon on the left, on the right, and alongside a `media` image — no crash. `/state` reflects the fields.

Companion: ha-pipup gains `icon` / `icon_position` / `icon_width` on `pipup.show` (position + width as per-device defaults).
