### PR TITLE
Support Android 6.0.1 (API 23) — projectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ Original app by [rogro82](https://github.com/rogro82/PiPup).
 Every version below has a [GitHub release](https://github.com/mhoogenbosch/PiPup/releases) with the
 full story (English and Dutch) and the APK.
 
+## [v0.14.0] — 2026-08-27 (runs on Android 6.0.1 / API 23)
+Reported: install failed with `INSTALL_FAILED_OLDER_SDK` on projectors running Android 6.0.1.
+### Changed
+- **`minSdk` lowered from 24 to 23**, so the app installs on Android 6.0.1 (API 23) — e.g. the
+  Android that ships on many projectors.
+- **Overlay window type on Android < 8** now uses `TYPE_SYSTEM_ALERT` (draws over other apps with the
+  overlay permission and can take input focus, so buttons work) instead of `TYPE_TOAST` (shows but
+  never focuses, and was restricted from Android 7.1). No effect on Android 8+ devices, which use
+  `TYPE_APPLICATION_OVERLAY`.
+- **`leanback` feature is no longer required** and the launcher activity also declares the normal
+  `LAUNCHER` category, so plain-Android devices (not just Android TV) install it and get an icon.
+
+The rest of the code was already version-guarded (foreground service, notification channel, screen
+wake via the pre-8.1 window flags, direct-boot prefs, self-update). Verified to build; runtime on
+Android 6 depends on the device.
+
 ## [v0.13.0] — 2026-08-25 (an icon beside the title and message)
 Requested (#19): show an icon next to the popup's title/message, notification-style.
 ### Added

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,10 +7,10 @@ android {
 
     defaultConfig {
         applicationId "nl.rogro82.pipup"
-        minSdkVersion 24
+        minSdkVersion 23
         targetSdkVersion 34
-        versionCode 35
-        versionName "0.13.0"
+        versionCode 36
+        versionName "0.14.0"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,9 +42,11 @@
     <uses-feature
             android:name="android.hardware.touchscreen"
             android:required="false"/>
+    <!-- Not required: also runs on plain-Android devices (e.g. Android 6 projectors),
+         not only Android TV. required="false" keeps it installable/visible there. -->
     <uses-feature
             android:name="android.software.leanback"
-            android:required="true"/>
+            android:required="false"/>
 
     <application
             android:allowBackup="true"
@@ -145,7 +147,10 @@
                 android:screenOrientation="landscape">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
+                <!-- LEANBACK_LAUNCHER for Android TV; LAUNCHER so plain-Android
+                     devices (projectors) also get a launcher icon. -->
                 <category android:name="android.intent.category.LEANBACK_LAUNCHER"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
     </application>

--- a/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
@@ -605,9 +605,14 @@ class PiPupService : Service(), WebServer.Handler {
             // create or reuse the current overlay; the window is only focusable when the
             // popup carries buttons (otherwise it must never steal the remote from the TV app)
 
+            @Suppress("DEPRECATION")
             val layoutFlags: Int = when {
                 Build.VERSION.SDK_INT >= Build.VERSION_CODES.O -> WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY
-                else -> WindowManager.LayoutParams.TYPE_TOAST
+                // Android 6/7 (< O): TYPE_SYSTEM_ALERT draws over other apps with the
+                // SYSTEM_ALERT_WINDOW permission (which PiPup is granted) and can take
+                // input focus, so buttons still work. TYPE_TOAST would show but never
+                // focus, and was restricted from 7.1 on.
+                else -> WindowManager.LayoutParams.TYPE_SYSTEM_ALERT
             }
 
             val windowFlags = if (popup.buttons.isNotEmpty())


### PR DESCRIPTION
Reported: `INSTALL_FAILED_OLDER_SDK` on projectors running Android 6.0.1.

## Changes
- **minSdk 24 → 23** — installs on Android 6.0.1 (API 23).
- **Overlay type on Android < 8** → `TYPE_SYSTEM_ALERT` (over-apps + focusable with the overlay permission PiPup is granted, so buttons work) instead of `TYPE_TOAST` (shows but never focuses; restricted from 7.1). Android 8+ unchanged (`TYPE_APPLICATION_OVERLAY`).
- **`leanback` no longer required** + launcher activity also declares the normal `LAUNCHER` category → plain-Android devices install it and get an icon, not only Android TV.

## Already compatible
Everything else was version-guarded: foreground service (O), notification channel (<26), screen wake (pre-8.1 window flags <27), direct-boot prefs (fall back <24), self-update. No dependency blockers (desugaring on; libs support minSdk 21+).

## Verified
APK reports `sdkVersion:'23'` with both a normal and a leanback launcher activity. Installs and runs without regression on the API 28+ fleet (popup shows, no crash). **Android 6 runtime not hardware-tested** — no API 23 device available; the reporter's projector is the test device.
