### PR TITLE
Fix Android 6/7 crash on first request: pin Jackson to 2.13.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Original app by [rogro82](https://github.com/rogro82/PiPup).
 Every version below has a [GitHub release](https://github.com/mhoogenbosch/PiPup/releases) with the
 full story (English and Dutch) and the APK.
 
+## [v0.14.1] — 2026-08-28 (fix Android 6/7 crash on first request)
+Field report: on Android 6.0.1 the app crashed at the first HTTP request with
+`NoClassDefFoundError: java.lang.BootstrapMethodError` from inside Jackson's `ObjectMapper`.
+### Fixed
+- `java.lang.BootstrapMethodError` only exists from Android 8.0 (API 26). Jackson references it in
+  `ExceptionUtil` from **2.14.0** onward, so `ObjectMapper` fails to load on API 23–25 and crashes the
+  request thread (`/state`, `/notify`, …) — which made v0.14.0 unusable on the very Android 6 devices it
+  was meant to support. **Jackson pinned back to 2.13.5** (the last line without that reference);
+  `kotlin-reflect` pinned to the project Kotlin version so it matches the stdlib. No API change.
+
 ## [v0.14.0] — 2026-08-27 (runs on Android 6.0.1 / API 23)
 Reported: install failed with `INSTALL_FAILED_OLDER_SDK` on projectors running Android 6.0.1.
 ### Changed

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "nl.rogro82.pipup"
         minSdkVersion 23
         targetSdkVersion 34
-        versionCode 36
-        versionName "0.14.0"
+        versionCode 37
+        versionName "0.14.1"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true
@@ -59,8 +59,15 @@ dependencies {
 
     implementation 'com.github.bumptech.glide:glide:4.16.0'
 
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.2'
-    implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.17.2'
+    // Jackson pinned to 2.13.x: from 2.14.0 on, ExceptionUtil references
+    // java.lang.BootstrapMethodError, which does not exist below Android API 26
+    // (Oreo). On API 23-25 (e.g. Android 6.0.1 projectors) loading ObjectMapper
+    // then throws NoClassDefFoundError and crashes the request thread. 2.13.5 is
+    // the last line without that reference. Keep kotlin-reflect at the project's
+    // Kotlin version so it matches the stdlib (module-kotlin would pull an old one).
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.5'
+    implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.13.5'
+    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
     implementation 'org.nanohttpd:nanohttpd:2.3.1'
 }


### PR DESCRIPTION
Field report on **Android 6.0.1**: crash on the first HTTP request —
`NoClassDefFoundError: java.lang.BootstrapMethodError` from Jackson's `ObjectMapper` static init (`ExceptionUtil.isFatal`).

## Cause
`java.lang.BootstrapMethodError` only exists from **Android 8.0 (API 26)**. Jackson references it in `ExceptionUtil` from **2.14.0** onward, so `ObjectMapper` fails to load on API 23–25 and crashes the request thread (`/state`, `/notify`, …) — making v0.14.0 unusable on the Android 6 devices the lowered minSdk was meant to support.

## Fix
- Pin the Jackson stack back to **2.13.5** (last line before the `BootstrapMethodError` reference).
- Pin `kotlin-reflect` to the project's Kotlin version so it matches the stdlib (module-kotlin would otherwise pull an old one).

## Verified
- The built dex contains **zero** references to `BootstrapMethodError` (was the crash source).
- No regression on the API 28 fleet: `/state` serialization and `/notify` **polymorphic** deserialization (`media` subtypes + `buttons` + `icon`) still work end-to-end.
- Android 6 runtime is the reporter's device (no API 23 hardware here), but the dex check is definitive that the offending reference is gone.
