### PR TITLE
Don't crash when a direct video_url (RTSP) fails: suppress VideoView error dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Original app by [rogro82](https://github.com/rogro82/PiPup).
 Every version below has a [GitHub release](https://github.com/mhoogenbosch/PiPup/releases) with the
 full story (English and Dutch) and the APK.
 
+## [v0.14.2] — 2026-08-28 (no crash on a failing direct video_url / RTSP stream)
+Field report (Android 6.0.1 projector): a direct `video_url: "rtsp://…"` crashed the app instantly.
+### Fixed
+- `VideoView` shows its built-in "Can't play this video" `AlertDialog` on any playback error or stall
+  (common with direct `rtsp://` URLs). This overlay runs from a `Service` with no activity window
+  token, so `Dialog.show()` threw `WindowManager$BadTokenException` and crashed the app. Added an
+  `OnErrorListener` that returns `true` (error handled → no dialog), so a failing/stalling stream can
+  no longer crash PiPup — the popup just stays hidden and is removed by its own duration timer.
+  Affects any Android version; surfaced by a direct RTSP stream.
+
 ## [v0.14.1] — 2026-08-28 (fix Android 6/7 crash on first request)
 Field report: on Android 6.0.1 the app crashed at the first HTTP request with
 `NoClassDefFoundError: java.lang.BootstrapMethodError` from inside Jackson's `ObjectMapper`.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "nl.rogro82.pipup"
         minSdkVersion 23
         targetSdkVersion 34
-        versionCode 37
-        versionName "0.14.1"
+        versionCode 38
+        versionName "0.14.2"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/app/src/main/java/nl/rogro82/pipup/PopupView.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PopupView.kt
@@ -193,6 +193,15 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
 
             mVideoView = VideoView(context).apply {
                 setVideoURI(Uri.parse(media.uri))
+                // Suppress VideoView's built-in "Can't play this video" AlertDialog. It is shown
+                // on any playback error or stall (common with direct rtsp:// URLs), but this overlay
+                // runs from a Service with no activity window token, so Dialog.show() throws
+                // BadTokenException and crashes the app. Returning true marks the error handled, so
+                // no dialog is shown; the popup stays hidden and is removed by its own duration timer.
+                setOnErrorListener { _, what, extra ->
+                    Log.w(LOG_TAG, "VideoView error (what=$what extra=$extra) for ${media.uri} — suppressing dialog")
+                    true
+                }
                 setOnPreparedListener {
                     if (media.muted) {
                         it.setVolume(0f, 0f)


### PR DESCRIPTION
Field report (Android 6.0.1 projector): a direct `video_url: "rtsp://…"` crashed the app instantly:

```
FATAL EXCEPTION: main
android.view.WindowManager$BadTokenException: Unable to add window -- token null is not for an application
  ... Dialog.show ... AlertDialog$Builder.show ... VideoView$5.onError(VideoView.java:530)
```

## Cause
`VideoView` shows its built-in "Can't play this video" `AlertDialog` on any playback error or stall (common with direct `rtsp://` URLs). The popup's VideoView runs from a **Service** (no activity window token), so `Dialog.show()` throws `BadTokenException` and crashes the process.

## Fix
Add an `OnErrorListener` that returns `true` (error handled → VideoView shows no dialog). A failing or stalling stream can no longer crash PiPup — the popup just stays hidden and is removed by its own duration timer. Affects any Android version; surfaced by a direct RTSP stream. `camera_entity` was unaffected (different path) and stays so.

Builds green locally.
