### PR TITLE
Self-update: always re-check GitHub before installing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ Original app by [rogro82](https://github.com/rogro82/PiPup).
 Every version below has a [GitHub release](https://github.com/mhoogenbosch/PiPup/releases) with the
 full story (English and Dutch) and the APK.
 
+## [v0.14.3] — 2026-08-28 (self-update installs the newest release, not the last-checked one)
+Field report: a TV running v0.13.0 was asked to update while v0.14.2 was out, and installed v0.14.0.
+### Fixed
+- The `/update` endpoint skipped its GitHub check whenever the **cached** release tag was already
+  newer than the running build (`if (!UpdateManager.updateAvailable) UpdateManager.check()`).
+  `installLatest()` then used the `downloadUrl` that the previous check had cached, so a cache from
+  before a newer release handed the installer that older APK. The skip only pays off while the cache
+  is fresh — which it is precisely *not* on a TV that has been behind for a while, and that is the
+  one case where this endpoint gets used. **The check now always runs on an install request.** A
+  failed check (offline, GitHub's anonymous 60/h rate limit) leaves the previous cache untouched, so
+  it still falls back to a known older release rather than doing nothing.
+- `UpdateManager.installLatest()` now documents that it installs the last *checked* release rather
+  than whatever is newest on GitHub at that moment — the name suggests otherwise and that is what
+  made the behaviour above easy to miss.
+
 ## [v0.14.2] — 2026-08-28 (no crash on a failing direct video_url / RTSP stream)
 Field report (Android 6.0.1 projector): a direct `video_url: "rtsp://…"` crashed the app instantly.
 ### Fixed

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "nl.rogro82.pipup"
         minSdkVersion 23
         targetSdkVersion 34
-        versionCode 38
-        versionName "0.14.2"
+        versionCode 39
+        versionName "0.14.3"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
@@ -966,7 +966,18 @@ class PiPupService : Service(), WebServer.Handler {
                                 OK("waiting for on-screen confirmation; popup shown again")
                             } else {
                                 Thread {
-                                    if (!UpdateManager.updateAvailable) UpdateManager.check()
+                                    // Always re-check first. `updateAvailable` compares the
+                                    // CACHED tag with the running build, so a cache from before
+                                    // a newer release still reads as "an update is available" --
+                                    // and installLatest() would then install that older APK from
+                                    // its cached downloadUrl. Skipping the check is only safe
+                                    // while the cache is fresh, which it is precisely not on a TV
+                                    // that has been behind for a while. Seen in the field: 0.13.0
+                                    // with 0.14.0 cached installed 0.14.0 while 0.14.2 was out.
+                                    // A failed check (offline, GitHub rate limit) leaves the
+                                    // previous cache untouched, so this still falls back to a
+                                    // known older release instead of doing nothing.
+                                    UpdateManager.check()
                                     if (UpdateManager.updateAvailable) {
                                         mHandler.post { showInstallingPopup() }
                                         UpdateManager.installLatest(this@PiPupService)

--- a/app/src/main/java/nl/rogro82/pipup/UpdateManager.kt
+++ b/app/src/main/java/nl/rogro82/pipup/UpdateManager.kt
@@ -127,7 +127,14 @@ object UpdateManager {
     }
 
     /// Download the release APK and hand it to the package installer. Blocking —
-    /// call from a background thread. Returns an error message, or null on success
+    /// call from a background thread.
+    ///
+    /// NB despite the name this installs the LAST CHECKED release, not whatever is
+    /// newest on GitHub right now: it uses the `downloadUrl` that [check] cached.
+    /// Callers that act on a user request must call [check] first, or they can hand
+    /// the installer a stale APK.
+    ///
+    /// Returns an error message, or null on success
     /// (success here means "handed to the installer": the actual result arrives
     /// asynchronously in the install receiver).
     fun installLatest(context: Context): String? {


### PR DESCRIPTION
## Field report

A TV running **v0.13.0** was asked to update while **v0.14.2** was out, and installed **v0.14.0**.

## Cause

The `/update` endpoint skipped its GitHub check whenever the **cached** release tag was already newer than the running build:

```kotlin
if (!UpdateManager.updateAvailable) UpdateManager.check()
```

`updateAvailable` only compares `UpdateManager.latestVersion` — the tag from the *last* check — with `BuildConfig.VERSION_NAME`. `installLatest()` then downloads `UpdateManager.downloadUrl`, cached by that same check. So on this TV: running 0.13.0, cached 0.14.0 from a check the day before → already "available" → **no re-check** → the installer got the 0.14.0 APK, while 0.14.1 and 0.14.2 had been released hours earlier.

The skip is an optimisation that only pays off while the cache is fresh — which it is precisely *not* on a TV that has been behind for a while, and that is the one case where this endpoint gets used.

## Fix

The check now always runs on an install request. A failed check (offline, GitHub's anonymous 60/h rate limit) leaves the previous cache untouched, so it still falls back to a known older release rather than doing nothing.

Also documents that `installLatest()` installs the last **checked** release rather than whatever is newest at that moment. The name suggests otherwise, which is what made this easy to miss.

## Verified

Reproduced and confirmed on the affected TV. After it had landed on 0.14.0 the app restarted with an empty cache, so the next request did check — and went straight from **0.14.0 to 0.14.2**, skipping 0.14.1. That is the same code path this PR now takes on every install request.

Ships as **v0.14.3** (versionCode 39); CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)