### PR TITLE
RTSP video via ExoPlayer; pass the remote through on Android < 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ Original app by [rogro82](https://github.com/rogro82/PiPup).
 Every version below has a [GitHub release](https://github.com/mhoogenbosch/PiPup/releases) with the
 full story (English and Dutch) and the APK.
 
+## [v0.15.0] — 2026-08-28 (RTSP video via ExoPlayer; remote passes through on Android <8)
+Field report: a direct `video_url: "rtsp://…"` didn't play (`MediaPlayer` error 1,-2147483648 / "No content
+provider") on Android 6 and 8, though it works in Alex Savin's separate app. Also on Android 6.0.1 the
+remote's D-pad/Back/Home were swallowed by a popup until it expired.
+### Added
+- **RTSP playback via ExoPlayer (media3).** `rtsp://` / `rtsps://` `video_url`s now play through ExoPlayer's
+  RTSP module (RTP-over-TCP forced — UDP is unreliable on Wi-Fi) instead of the stock `VideoView`, which
+  cannot play RTSP reliably. Everything else (http/HLS, `camera_entity`) stays on `VideoView`, and the
+  media3 classes only load when an rtsp URL is actually shown — no impact on other popups or devices.
+### Fixed
+- On Android < 8 a button-less popup (`TYPE_SYSTEM_ALERT`) could swallow the remote's D-pad/Back/Home
+  until it expired; it now also sets `FLAG_NOT_TOUCHABLE`, so it is fully input-transparent and keys reach
+  the app behind it. Android 8+ (`TYPE_APPLICATION_OVERLAY`) already passed input through and is unchanged.
+
 ## [v0.14.3] — 2026-08-28 (self-update installs the newest release, not the last-checked one)
 Field report: a TV running v0.13.0 was asked to update while v0.14.2 was out, and installed v0.14.0.
 ### Fixed

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "nl.rogro82.pipup"
         minSdkVersion 23
         targetSdkVersion 34
-        versionCode 39
-        versionName "0.14.3"
+        versionCode 40
+        versionName "0.15.0"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true
@@ -70,4 +70,13 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
     implementation 'org.nanohttpd:nanohttpd:2.3.1'
+
+    // ExoPlayer (media3) — used ONLY for rtsp:// video_url. Android's stock VideoView/MediaPlayer
+    // cannot reliably play RTSP (fails with MEDIA_ERROR_UNKNOWN); ExoPlayer's RTSP module can, and
+    // supports TCP interleaving. Kept off the default video path (http/HLS/camera_entity stays on
+    // VideoView), and the classes only load when an rtsp URL is actually shown — so no impact on
+    // other popups or on Android 6 devices that never use rtsp. minSdk 21, safe for our minSdk 23.
+    implementation 'androidx.media3:media3-exoplayer:1.5.1'
+    implementation 'androidx.media3:media3-exoplayer-rtsp:1.5.1'
+    implementation 'androidx.media3:media3-ui:1.5.1'
 }

--- a/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
@@ -617,8 +617,18 @@ class PiPupService : Service(), WebServer.Handler {
 
             val windowFlags = if (popup.buttons.isNotEmpty())
                 WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL
-            else
-                WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
+            else {
+                // A button-less popup must never take input. On Android < 8 the overlay is a
+                // TYPE_SYSTEM_ALERT window, which was reported to swallow the remote's D-pad/Back/Home
+                // on Android 6 until the popup expired; add FLAG_NOT_TOUCHABLE there so the window is
+                // fully input-transparent and keys reach the launcher behind it. On 8+ the
+                // TYPE_APPLICATION_OVERLAY + FLAG_NOT_FOCUSABLE already passes input through, so leave
+                // that path unchanged.
+                var f = WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O)
+                    f = f or WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE
+                f
+            }
 
             val params = WindowManager.LayoutParams(
                 WindowManager.LayoutParams.MATCH_PARENT,

--- a/app/src/main/java/nl/rogro82/pipup/PopupView.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PopupView.kt
@@ -17,6 +17,13 @@ import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.*
+import androidx.media3.common.MediaItem
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.Player
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.rtsp.RtspMediaSource
+import androidx.media3.ui.PlayerView
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 
@@ -180,7 +187,8 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
     }
 
     private class Video(context: Context, popup: PopupProps, val media: PopupProps.Media.Video): PopupView(context, popup) {
-        private lateinit var mVideoView: VideoView
+        private var mVideoView: VideoView? = null
+        private var mExoPlayer: ExoPlayer? = null
 
         init { create() }
 
@@ -191,6 +199,51 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
 
             val frame = findViewById<FrameLayout>(R.id.popup_frame)
 
+            // rtsp:// goes through ExoPlayer (stock VideoView/MediaPlayer can't play RTSP reliably —
+            // it fails with MEDIA_ERROR_UNKNOWN). Everything else keeps the existing VideoView path,
+            // and the ExoPlayer/media3 classes only load when an rtsp URL is actually shown.
+            val uri = media.uri
+            if (uri.startsWith("rtsp://", ignoreCase = true) || uri.startsWith("rtsps://", ignoreCase = true)) {
+                createRtsp(frame, uri)
+            } else {
+                createVideoView(frame)
+            }
+        }
+
+        /// ExoPlayer path for rtsp://. Forces RTP-over-TCP: UDP interleave is frequently blocked or
+        /// unreliable on Wi-Fi, and most IP cameras / RTSP servers support TCP. Errors are logged
+        /// (ExoPlayer shows no system dialog, so a failing stream cannot crash us); the popup is
+        /// revealed on the first rendered frame and removed by its own duration timer otherwise.
+        @UnstableApi
+        private fun createRtsp(frame: FrameLayout, uri: String) {
+            val playerView = PlayerView(context).apply {
+                useController = false
+                layoutParams = FrameLayout.LayoutParams(media.width, LayoutParams.WRAP_CONTENT).apply {
+                    gravity = Gravity.CENTER
+                }
+            }
+            val source = RtspMediaSource.Factory()
+                .setForceUseRtpTcp(true)
+                .createMediaSource(MediaItem.fromUri(uri))
+            mExoPlayer = ExoPlayer.Builder(context).build().apply {
+                if (media.muted) volume = 0f
+                addListener(object : Player.Listener {
+                    override fun onPlayerError(error: PlaybackException) {
+                        Log.w(LOG_TAG, "ExoPlayer RTSP error for $uri: ${error.errorCodeName}", error)
+                    }
+                    override fun onRenderedFirstFrame() {
+                        this@Video.visibility = View.VISIBLE
+                    }
+                })
+                setMediaSource(source)
+                playWhenReady = true
+                prepare()
+            }
+            playerView.player = mExoPlayer
+            frame.addView(playerView)
+        }
+
+        private fun createVideoView(frame: FrameLayout) {
             mVideoView = VideoView(context).apply {
                 setVideoURI(Uri.parse(media.uri))
                 // Suppress VideoView's built-in "Can't play this video" AlertDialog. It is shown
@@ -227,9 +280,12 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
         override fun destroy() {
             super.destroy()
             try {
-                if(mVideoView.isPlaying) {
-                    mVideoView.stopPlayback()
-                }
+                mVideoView?.let { if (it.isPlaying) it.stopPlayback() }
+                mVideoView = null
+            } catch(e: Throwable) {}
+            try {
+                mExoPlayer?.release()
+                mExoPlayer = null
             } catch(e: Throwable) {}
         }
     }


### PR DESCRIPTION
Field report (Android 6.0.1 projector + Android 8 TCL): a direct `video_url: "rtsp://…"` doesn't play — stock `MediaPlayer` fails with `error (1, -2147483648)` / "No content provider" — though it works in Alex Savin's separate app (ExoPlayer-based). Also on Android 6.0.1 the remote's D-pad/Back/Home were swallowed by a popup until it expired.

## Changes
- **RTSP via ExoPlayer (media3).** `rtsp://` / `rtsps://` `video_url`s play through ExoPlayer's RTSP module (RTP-over-TCP forced) instead of `VideoView`, which can't play RTSP reliably. Everything else (http/HLS, `camera_entity`) stays on `VideoView`, and the media3 classes only load when an rtsp URL is actually shown — no impact on other popups or on devices that never use rtsp. ExoPlayer shows no system dialog, so a failing stream can't crash the app either.
- **Input pass-through on Android < 8.** A button-less popup uses a `TYPE_SYSTEM_ALERT` overlay there, which was reported to swallow the remote until the popup expired; it now also sets `FLAG_NOT_TOUCHABLE`. Android 8+ (`TYPE_APPLICATION_OVERLAY` + `FLAG_NOT_FOCUSABLE`) already passed input through and is unchanged.

## Verified
API 28 TV: a bogus `rtsp://` URL errors gracefully (`ExoPlayer RTSP error … ERROR_CODE_IO_UNSPECIFIED`) with no crash; `/state`, the image and `VideoView` paths are unaffected. APK grew ~2 MB (media3). Real RTSP playback and the Android-6 input fix are the reporter's devices to confirm.
