### PR TITLE
Poster: a still over the stream area until the first frame renders (0.17.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ Original app by [rogro82](https://github.com/rogro82/PiPup).
 Every version below has a [GitHub release](https://github.com/mhoogenbosch/PiPup/releases) with the
 full story (English and Dutch) and the APK.
 
+## [v0.17.0] — 2026-08-29 (poster: never an empty popup while the stream connects)
+A live popup opened as an empty box for the seconds an RTSP handshake, a keyframe wait or a WebView
+start-up takes — measured 5–6 s (RTSP) and ~1 s (WebView) on a Fire TV and a Nokia 8010 — exactly the
+seconds that matter when someone is at the door.
+### Added
+- **`poster`** (optional) on `media.video` and `media.web`: URL of a still image (e.g. a camera snapshot)
+  shown over the stream area the moment the popup appears and **faded out (150 ms) on the stream's first
+  rendered frame** — `onRenderedFirstFrame` for video, `onPageCommitVisible` for web (deliberately not
+  `onPageFinished`, which never fires for an MJPEG stream). If the poster fails to load nothing happens; if
+  the stream never paints, the poster simply stays — a snapshot from seconds ago beats an empty frame, so
+  there is no timeout. Update-in-place of the same popup keeps the running stream and lays no new poster
+  over it. Additive: payloads without `poster` behave exactly as before.
+- The stream area **takes the poster's own aspect** as soon as it is decoded (a snapshot has the camera's
+  aspect), so still and live line up exactly with no size jump at hand-over. For `web` this replaces the
+  caller's height hint.
+- **`/state.lastPopup.firstFrameMs`**: milliseconds from popup creation to the first rendered frame of a
+  video/web popup (`null` until painted). Makes the start-up cost — and the poster's gain — measurable from
+  the Home Assistant diagnostics. `lastPopup.media.poster` tells whether a poster was used.
+
 ## [v0.16.0] — 2026-08-29 (all video via ExoPlayer + TextureView; VideoView removed)
 Follow-through on the v0.15.1 finding: the HLS/http `video_url` path (and therefore the HA integration's
 `camera_mode: stream`) still used the stock `VideoView` and had the same hardware-video-plane problem.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "nl.rogro82.pipup"
         minSdkVersion 23
         targetSdkVersion 34
-        versionCode 42
-        versionName "0.16.0"
+        versionCode 43
+        versionName "0.17.0"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
@@ -44,6 +44,8 @@ class PiPupService : Service(), WebServer.Handler {
     // in /state so you can verify at the TV what HA actually sent.
     @Volatile private var mLastPopup: PopupProps? = null
     @Volatile private var mLastPopupAt: Long = 0L
+    /// ms from view creation to first rendered frame of the last video/web popup; null until known
+    @Volatile private var mLastFirstFrameMs: Long? = null
     private val mPopupsShown = java.util.concurrent.atomic.AtomicLong(0)
     private val mStartedAt: Long = SystemClock.elapsedRealtime()
     private lateinit var mWebServer: WebServer
@@ -578,6 +580,7 @@ class PiPupService : Service(), WebServer.Handler {
 
             mLastPopup = popup
             mLastPopupAt = SystemClock.elapsedRealtime()
+            mLastFirstFrameMs = null
 
             // update-in-place: same id and same content -> keep the view (and its
             // video/web stream) alive and only reschedule the removal timer
@@ -668,6 +671,7 @@ class PiPupService : Service(), WebServer.Handler {
                 // inflate the popup layout
 
                 mPopup = PopupView.build(this, popup)
+                mPopup?.onFirstFrame = { ms -> mLastFirstFrameMs = ms }
 
                 mPopup?.onButton = { btn ->
                     // The app's own update popups are handled locally; they have no
@@ -789,6 +793,8 @@ class PiPupService : Service(), WebServer.Handler {
                 "media" to mediaInfo(last),
                 "tts" to !last.tts.isNullOrBlank(),
                 "buttons" to last.buttons.size,
+                // time to first rendered frame (video/web); null while not yet painted or n/a
+                "firstFrameMs" to mLastFirstFrameMs,
                 "secondsAgo" to ((SystemClock.elapsedRealtime() - mLastPopupAt) / 1000)
             )
         }
@@ -936,8 +942,8 @@ class PiPupService : Service(), WebServer.Handler {
 
     /// Media summary for /state's lastPopup: {type, width, height?} or null.
     private fun mediaInfo(p: PopupProps): Map<String, Any?>? = when (val m = p.media) {
-        is PopupProps.Media.Web -> mapOf("type" to "web", "width" to m.width, "height" to m.height)
-        is PopupProps.Media.Video -> mapOf("type" to "video", "width" to m.width)
+        is PopupProps.Media.Web -> mapOf("type" to "web", "width" to m.width, "height" to m.height, "poster" to (m.poster != null))
+        is PopupProps.Media.Video -> mapOf("type" to "video", "width" to m.width, "poster" to (m.poster != null))
         is PopupProps.Media.Image -> mapOf("type" to "image", "width" to m.width)
         is PopupProps.Media.Bitmap -> mapOf("type" to "bitmap", "width" to m.width)
         null -> null

--- a/app/src/main/java/nl/rogro82/pipup/PopupProps.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PopupProps.kt
@@ -55,11 +55,16 @@ data class PopupProps(
     )
     sealed class Media {
         @JsonIgnoreProperties(ignoreUnknown = true)
-        data class Video(val uri: String, val width: Int = DEFAULT_MEDIA_WIDTH, val muted: Boolean = false): Media()
+        // `poster` (optional, video + web): URL of a still image shown immediately over the
+        // stream area and faded out on the first rendered frame, so a live popup never opens
+        // as an empty box while the stream connects (RTSP handshake, WebView start-up).
+        data class Video(val uri: String, val width: Int = DEFAULT_MEDIA_WIDTH, val muted: Boolean = false,
+                         val poster: String? = null): Media()
         @JsonIgnoreProperties(ignoreUnknown = true)
         data class Image(val uri: String, val width: Int = DEFAULT_MEDIA_WIDTH): Media()
         @JsonIgnoreProperties(ignoreUnknown = true)
-        data class Web(val uri: String, val width: Int = 640, val height: Int = 480, val muted: Boolean = false): Media()
+        data class Web(val uri: String, val width: Int = 640, val height: Int = 480, val muted: Boolean = false,
+                       val poster: String? = null): Media()
         data class Bitmap(val image: android.graphics.Bitmap, val width: Int = DEFAULT_MEDIA_WIDTH): Media()
     }
 

--- a/app/src/main/java/nl/rogro82/pipup/PopupView.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PopupView.kt
@@ -29,6 +29,8 @@ import androidx.media3.exoplayer.rtsp.RtspMediaSource
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.DiskCacheStrategy
+import com.bumptech.glide.request.target.CustomTarget
+import com.bumptech.glide.request.transition.Transition
 
 // TODO: convert dimensions from px to dp
 
@@ -37,6 +39,76 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
 
     /// set by the service after build(); invoked when the user presses a popup button
     var onButton: ((PopupProps.Button) -> Unit)? = null
+
+    /// set by the service after build(); invoked once, with the milliseconds between this
+    /// view's creation and the first rendered frame of its stream (video/web). Reported in
+    /// /state.lastPopup.firstFrameMs so the start-up cost of a live popup is measurable.
+    var onFirstFrame: ((Long) -> Unit)? = null
+    private val mCreatedAt = android.os.SystemClock.elapsedRealtime()
+    private var mFirstFrameReported = false
+
+    /// Poster: a still image (e.g. a camera snapshot) laid over the stream area the moment
+    /// the popup appears, so a live popup never opens as an empty box while the stream
+    /// connects (RTSP handshake, WebView start-up, waiting for a keyframe). Faded out on
+    /// the first rendered frame. If the poster fails to load nothing happens (Glide fails
+    /// silently); if the stream never paints the poster simply stays — a snapshot from
+    /// seconds ago beats an empty frame, so there is deliberately no timeout.
+    protected var mPoster: ImageView? = null
+
+    /// `onSized` receives the poster's intrinsic width/height once decoded, so the caller can
+    /// give the stream area the poster's aspect ratio right away. A camera snapshot has the same
+    /// aspect as the camera's stream, so still and live then line up exactly and the hand-over
+    /// shows no size jump (a provisional 16:9 box letterboxed a 4:3 snapshot, then jumped).
+    protected fun attachPoster(frame: FrameLayout, url: String?, params: FrameLayout.LayoutParams,
+                               onSized: ((Int, Int) -> Unit)? = null) {
+        if (url.isNullOrEmpty()) return
+        val iv = ImageView(context).apply {
+            scaleType = ImageView.ScaleType.FIT_XY   // box already has the image's aspect
+            setBackgroundColor(Color.TRANSPARENT)
+        }
+        frame.addView(iv, params)   // added after the stream view => drawn on top
+        mPoster = iv
+        try {
+            Glide.with(context).asBitmap().load(url)
+                .diskCacheStrategy(DiskCacheStrategy.NONE).skipMemoryCache(true)
+                .into(object : CustomTarget<android.graphics.Bitmap>() {
+                    override fun onResourceReady(resource: android.graphics.Bitmap, transition: Transition<in android.graphics.Bitmap>?) {
+                        if (mPoster !== iv) return   // already handed over / destroyed
+                        iv.setImageBitmap(resource)
+                        if (resource.width > 0 && resource.height > 0) onSized?.invoke(resource.width, resource.height)
+                    }
+                    override fun onLoadCleared(placeholder: android.graphics.drawable.Drawable?) { iv.setImageDrawable(null) }
+                    override fun onLoadFailed(errorDrawable: android.graphics.drawable.Drawable?) {
+                        Log.w(LOG_TAG, "poster failed to load: $url")
+                    }
+                })
+        } catch (_: Throwable) {}
+    }
+
+    /// Called by the subclass when its stream rendered its first frame: fades the poster out
+    /// (150 ms, then removed) and reports firstFrameMs once.
+    protected fun onStreamFirstFrame() {
+        if (!mFirstFrameReported) {
+            mFirstFrameReported = true
+            val ms = android.os.SystemClock.elapsedRealtime() - mCreatedAt
+            Log.d(LOG_TAG, "first frame after ${ms} ms" + (if (mPoster != null) " (poster shown)" else ""))
+            try { onFirstFrame?.invoke(ms) } catch (_: Throwable) {}
+        }
+        val iv = mPoster ?: return
+        mPoster = null
+        iv.animate().alpha(0f).setDuration(150).withEndAction {
+            try { Glide.with(context).clear(iv) } catch (_: Throwable) {}
+            (iv.parent as? ViewGroup)?.removeView(iv)
+        }.start()
+    }
+
+    protected fun destroyPoster() {
+        mPoster?.let { iv ->
+            try { Glide.with(context).clear(iv) } catch (_: Throwable) {}
+            iv.setImageDrawable(null)
+        }
+        mPoster = null
+    }
 
     private var mProgressAnimator: ObjectAnimator? = null
 
@@ -229,9 +301,13 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
             // aspect on onVideoSizeChanged.
             fun sizeTo(w: Int, h: Int) {
                 textureView.layoutParams = FrameLayout.LayoutParams(w, h).apply { gravity = Gravity.CENTER }
+                mPoster?.layoutParams = FrameLayout.LayoutParams(w, h).apply { gravity = Gravity.CENTER }
                 this@Video.visibility = View.VISIBLE
             }
             frame.addView(textureView)
+            attachPoster(frame, media.poster,
+                FrameLayout.LayoutParams(media.width, media.width * 9 / 16).apply { gravity = Gravity.CENTER }
+            ) { pw, ph -> sizeTo(media.width, (media.width.toLong() * ph / pw).toInt()) }
             sizeTo(media.width, media.width * 9 / 16)
 
             val isRtsp = uri.startsWith("rtsp://", ignoreCase = true) || uri.startsWith("rtsps://", ignoreCase = true)
@@ -255,6 +331,9 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
                             sizeTo(media.width, (media.width.toLong() * videoSize.height / videoSize.width).toInt())
                         }
                     }
+                    override fun onRenderedFirstFrame() {
+                        onStreamFirstFrame()
+                    }
                     override fun onPlayerError(error: PlaybackException) {
                         Log.w(LOG_TAG, "ExoPlayer error for $uri: ${error.errorCodeName}", error)
                     }
@@ -267,6 +346,7 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
 
         override fun destroy() {
             super.destroy()
+            destroyPoster()
             try {
                 mExoPlayer?.release()
                 mExoPlayer = null
@@ -355,14 +435,18 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
                     mediaPlaybackRequiresUserGesture = false
                     mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
                 }
-                if (media.muted) {
-                    // mute every (also dynamically added) media element, so the
-                    // page never claims audio focus (audio can stall video on
-                    // some Android TV / Fire TV devices)
-                    webViewClient = object : WebViewClient() {
-                        override fun onPageFinished(view: WebView?, url: String?) {
-                            view?.evaluateJavascript(MUTE_JS, null)
-                        }
+                webViewClient = object : WebViewClient() {
+                    // First visible paint of the page. Used for the poster hand-over and
+                    // the firstFrameMs measurement. Deliberately NOT onPageFinished: that
+                    // fires when everything has loaded, and an MJPEG stream never finishes.
+                    override fun onPageCommitVisible(view: WebView?, url: String?) {
+                        onStreamFirstFrame()
+                    }
+                    override fun onPageFinished(view: WebView?, url: String?) {
+                        // mute every (also dynamically added) media element, so the
+                        // page never claims audio focus (audio can stall video on
+                        // some Android TV / Fire TV devices)
+                        if (media.muted) view?.evaluateJavascript(MUTE_JS, null)
                     }
                 }
                 loadUrl(media.uri)
@@ -377,10 +461,20 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
             }
 
             frame.addView(webView, layoutParams)
+            attachPoster(frame, media.poster,
+                FrameLayout.LayoutParams(media.width, media.height).apply { gravity = Gravity.CENTER }
+            ) { pw, ph ->
+                // Give the web view the poster's aspect at the requested width, so still and
+                // live stream match (an MJPEG page scales the image to the view width anyway).
+                val h = (media.width.toLong() * ph / pw).toInt()
+                webView.layoutParams = FrameLayout.LayoutParams(media.width, h).apply { gravity = Gravity.CENTER }
+                mPoster?.layoutParams = FrameLayout.LayoutParams(media.width, h).apply { gravity = Gravity.CENTER }
+            }
         }
 
         override fun destroy() {
             super.destroy()
+            destroyPoster()
             try {
                 mWebView?.apply {
                     loadUrl("about:blank")

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,11 @@ streams) on your TV from your home-automation system, for **as long as you want*
   (multipart), which previously ignored `urgency` and `showProgress` entirely.
 - **Icon beside the text** (since 0.13.0) — an optional `icon` (image URL) shown next to the
   title/message, notification-style, with `iconPosition` (`left`/`right`) and `iconWidth`.
+- **Poster** (since 0.17.0) — an optional `poster` (image URL) on `video` and `web` media: a still
+  (e.g. a camera snapshot) shown over the stream area the moment the popup appears and faded out on
+  the stream's first rendered frame. A live popup never opens as an empty box while the RTSP handshake
+  or WebView start-up runs; the stream area takes the poster's aspect, so still and live line up. If the
+  stream never paints the poster simply stays. `/state.lastPopup.firstFrameMs` reports the time to first frame.
 - **Screen on/off** (since 0.7.0) — `POST /power?state=on|off|toggle` wakes the TV or puts it in
   standby, without a second integration for ADB or HDMI-CEC. `/state` publishes what is actually
   possible on this device (`power.canSleep`, `power.sleepMethod`) instead of accepting a request it
@@ -315,6 +320,17 @@ All fields are optional. For `media` you can specify 3 types:
 { "image": { "uri": "address_to_your_image", "width": 480 }}
 { "video": { "uri": "address_to_your_video", "width": 480, "muted": true }}
 { "web":   { "uri": "address_to_your_resource", "width": 640, "height": 480, "muted": true }}
+```
+
+`poster` (since 0.17.0, video and web): URL of a still image shown over the stream area until the
+stream renders its first frame, then faded out. Use a camera snapshot (e.g. Frigate
+`/api/<cam>/latest.jpg`) so the popup shows a picture instantly instead of an empty frame while
+RTSP connects or the WebView starts. The stream area takes the poster's aspect, so still and live
+match. If the poster fails to load nothing happens; if the stream never paints, the poster stays.
+`/state.lastPopup.firstFrameMs` reports the time to first frame.
+
+```json
+{ "video": { "uri": "rtsp://cam/sub", "width": 640, "poster": "http://frigate:5000/api/cam/latest.jpg" }}
 ```
 
 `muted` (since 0.2.4, default `false`): plays the video/web media without audio. For web media every


### PR DESCRIPTION
A live popup opened as an **empty box** for the seconds an RTSP handshake, a keyframe wait or a WebView start-up takes — measured **5–6 s (RTSP)** and **~1 s (WebView)** on a Fire TV and a Nokia 8010 via the new `firstFrameMs` — exactly the seconds that matter when someone is at the door.

## Added
- **`poster`** (optional) on `media.video` and `media.web`: URL of a still (e.g. a camera snapshot) shown over the stream area the moment the popup appears, **faded out (150 ms) on the stream's first rendered frame** — `onRenderedFirstFrame` (video) / `onPageCommitVisible` (web; not `onPageFinished`, which never fires for MJPEG). Fails silently if it can't load; stays if the stream never paints (deliberately no timeout). Update-in-place keeps the stream and lays no new poster. Additive.
- The stream area **takes the poster's own aspect** as soon as it is decoded (a snapshot has the camera's aspect), so still and live line up exactly — the first build used a provisional 16:9 box and showed a visible size jump at hand-over; fixed before release.
- **`/state.lastPopup.firstFrameMs`** + `lastPopup.media.poster` — the start-up cost and the poster's gain are measurable from the HA diagnostics.

## Verified (Nokia 8010 / Android 14, Fire TV / Android 9)
Full suite green incl. poster variants: still instant, same size as live, smooth hand-over; buttons event received; no errors. Companion: ha-pipup 1.15.0 (`poster_url` + automatic poster for `camera_entity`).
