### PR TITLE
/notify and /cancel answer once /state reflects the change (0.17.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ Original app by [rogro82](https://github.com/rogro82/PiPup).
 Every version below has a [GitHub release](https://github.com/mhoogenbosch/PiPup/releases) with the
 full story (English and Dutch) and the APK.
 
+## [v0.17.1] — 2026-08-29 (`/notify` and `/cancel` answer once `/state` reflects the change)
+The HTTP thread used to post the popup to the main thread and reply `200` at once. Measured on a Nokia
+8010, `/state` read ~20 ms after that reply still showed no popup; ~75 ms later it did. A client that
+refreshes its state right after the call (the Home Assistant integration's popup sensor, since ha-pipup
+1.15.1) saw the previous state and stayed stale until its next poll.
+### Changed
+- **`/notify` waits for the popup view to be built before answering**, so a `200` now means "the popup
+  is on screen and `/state` shows it". It waits for the view, not for its media — an RTSP handshake or
+  a WebView start-up never holds the reply. `/cancel` likewise answers after the popup is gone. If the
+  main thread does not get to the request within 2 s (stuck UI), the reply is still `200` with
+  "accepted; … still queued" rather than a hung connection.
+- A popup that **fails to build now answers `500`** ("popup could not be created") instead of `200` —
+  before, such a failure was only visible in logcat while the caller believed the popup was shown.
+### Fixed
+- **Two requests in quick succession could silently drop the second.** The hand-off to the main thread
+  used the popup handler, and `createPopup`/`removePopup` clear that handler's queue
+  (`removeCallbacksAndMessages(null)`) — a second `/notify` still queued behind the first was discarded
+  while its caller had been told `200`. Requests now go through their own handler.
+
 ## [v0.17.0] — 2026-08-29 (poster: never an empty popup while the stream connects)
 A live popup opened as an empty box for the seconds an RTSP handshake, a keyframe wait or a WebView
 start-up takes — measured 5–6 s (RTSP) and ~1 s (WebView) on a Fire TV and a Nokia 8010 — exactly the

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "nl.rogro82.pipup"
         minSdkVersion 23
         targetSdkVersion 34
-        versionCode 43
-        versionName "0.17.0"
+        versionCode 44
+        versionName "0.17.1"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
@@ -29,10 +29,17 @@ import fi.iki.elonen.NanoHTTPD.newFixedLengthResponse
 import java.io.File
 import java.util.Locale
 import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 
 class PiPupService : Service(), WebServer.Handler {
     private val mHandler: Handler = Handler(Looper.getMainLooper())
+    // Hand-off of HTTP requests (/notify, /cancel) to the main thread. Deliberately NOT
+    // mHandler: createPopup/removePopup call mHandler.removeCallbacksAndMessages(null),
+    // which would also drop a second request that was still queued behind the first —
+    // that popup then silently never appeared while its caller had been told OK.
+    private val mRequestHandler: Handler = Handler(Looper.getMainLooper())
     private var mOverlay: FrameLayout? = null
     private var mPopup: PopupView? = null
     // Written on the main thread, read by the NanoHTTPD worker thread in /state:
@@ -573,7 +580,9 @@ class PiPupService : Service(), WebServer.Handler {
     }
 
     @Suppress("DEPRECATION")
-    private fun createPopup(popup: PopupProps) {
+    /// Returns true when the popup is on screen (or updated in place) and /state reflects
+    /// it; false when building it threw. /notify waits for this result before answering.
+    private fun createPopup(popup: PopupProps): Boolean {
         try {
 
             Log.d(LOG_TAG, "Create popup: $popup")
@@ -598,7 +607,7 @@ class PiPupService : Service(), WebServer.Handler {
                 }
                 mCurrentProps = popup
                 scheduleRemoval(popup)
-                return
+                return true
             }
 
             // remove current popup
@@ -731,10 +740,35 @@ class PiPupService : Service(), WebServer.Handler {
             // schedule removal
 
             scheduleRemoval(popup)
+            return true
 
         } catch (ex: Throwable) {
-            ex.printStackTrace()
+            Log.e(LOG_TAG, "Create popup failed: ${ex.message}", ex)
+            return false
         }
+    }
+
+    /// Runs [block] on the main thread and waits for it to finish (at most
+    /// MAIN_SYNC_TIMEOUT_MS). Returns the block's result, or null when the main thread did
+    /// not get to it in time — the request stays queued and still runs, the caller just
+    /// cannot confirm it. Used so that /notify and /cancel answer only once /state
+    /// reflects the change: the HA integration refreshes its popup sensor right after the
+    /// call, and measured on a Nokia 8010 the popup showed up in /state 20–75 ms *after*
+    /// the old fire-and-forget reply — a refresh in that window saw the previous state.
+    private fun runOnMainSync(block: () -> Boolean): Boolean? {
+        val latch = CountDownLatch(1)
+        var result: Boolean? = null
+        mRequestHandler.post {
+            try {
+                result = block()
+            } catch (ex: Throwable) {
+                Log.e(LOG_TAG, "Main-thread request failed: ${ex.message}", ex)
+                result = false
+            } finally {
+                latch.countDown()
+            }
+        }
+        return if (latch.await(MAIN_SYNC_TIMEOUT_MS, TimeUnit.MILLISECONDS)) result else null
     }
 
     private fun stateResponse(): NanoHTTPD.Response {
@@ -1013,10 +1047,11 @@ class PiPupService : Service(), WebServer.Handler {
                             if (id != null && current != null && current.id != id) {
                                 OK("id mismatch: visible popup is ${current.id}")
                             } else {
-                                mHandler.post {
-                                    removePopup(true)
+                                // answer only once the popup is gone from /state (0.17.1)
+                                when (runOnMainSync { removePopup(true); true }) {
+                                    null -> OK("accepted; main thread busy, removal still queued")
+                                    else -> OK()
                                 }
-                                OK()
                             }
                         }
                         "/notify" -> {
@@ -1142,11 +1177,14 @@ class PiPupService : Service(), WebServer.Handler {
 
                                 Log.d(LOG_TAG, "received popup: $popup")
 
-                                mHandler.post {
-                                    createPopup(popup)
+                                // Answer only once the popup exists and /state reflects it
+                                // (0.17.1). Waits for the view to be built, not for its media
+                                // to load — an RTSP handshake must not hold the reply.
+                                when (runOnMainSync { createPopup(popup) }) {
+                                    true -> OK("$popup")
+                                    false -> ServerError("popup could not be created (see logcat)")
+                                    null -> OK("accepted; main thread busy, popup still queued: $popup")
                                 }
-
-                                OK("$popup")
 
 
                             } catch (ex: Throwable) {
@@ -1184,8 +1222,13 @@ class PiPupService : Service(), WebServer.Handler {
         const val MAX_JSON_BODY_BYTES = 256 * 1024
         const val MULTIPART_FORM_DATA = "multipart/form-data"
         const val APPLICATION_JSON = "application/json"
+        // How long /notify and /cancel wait for the main thread before answering anyway.
+        // Building a popup view takes tens of ms; 2 s only elapses when the UI thread is
+        // stuck, and then a held-open HTTP connection would help nobody.
+        const val MAIN_SYNC_TIMEOUT_MS = 2_000L
 
         fun OK(message: String? = null): NanoHTTPD.Response = newFixedLengthResponse(NanoHTTPD.Response.Status.OK, "text/plain", message)
         fun InvalidRequest(message: String? = null): NanoHTTPD.Response = newFixedLengthResponse(NanoHTTPD.Response.Status.BAD_REQUEST, "text/plain", "invalid request: $message")
+        fun ServerError(message: String? = null): NanoHTTPD.Response = newFixedLengthResponse(NanoHTTPD.Response.Status.INTERNAL_ERROR, "text/plain", "error: $message")
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,9 @@ streams) on your TV from your home-automation system, for **as long as you want*
 - **`/state` endpoint** — popup visibility, screen on/off (`screenOn`, since 0.2.3), popup counter,
   uptime, device info and a **stable device id** (since 0.2.5).
 - **`/cancel`** (existed upstream but undocumented) with optional selective `?id=`.
+- **`/notify` and `/cancel` answer once `/state` reflects the change** (since 0.17.1) — a `200` means the
+  popup is on (or off) screen, so a client may read `/state` straight after the call. The reply waits for
+  the view, not for its media to load. A popup that fails to build answers `500`.
 - **Muted media** (since 0.2.4) — `muted: true` on video/web media plays without audio, so a popup
   never claims audio focus (audio in a popup can freeze video playback on some devices).
 - **Text-to-speech** (since 0.2.5) — a `tts` field speaks a text on the TV when the popup appears,


### PR DESCRIPTION
## Changed
- **`/notify` waits for the popup view to be built before answering** (max 2 s), so `200` means "the popup is on screen and `/state` shows it". Waits for the view, not for its media — an RTSP handshake never holds the reply. `/cancel` answers after the popup is gone.
- A popup that fails to build answers `500` instead of `200`.

## Fixed
- Two requests in quick succession could silently drop the second: the hand-off used `mHandler`, whose queue `createPopup`/`removePopup` clear with `removeCallbacksAndMessages(null)`. Requests now use their own handler.

## Why
Measured on a Nokia 8010: `/state` read ~20 ms after the old fire-and-forget reply still showed no popup, ~75 ms later it did. The HA integration (ha-pipup ≥ 1.15.1) refreshes its popup sensor right after the call and saw the previous state until the next 15 s poll.

Bumps versionCode 44 / 0.17.1; changelog + readme updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)