### PR TITLE
Software video decoding on Android < 8 / Amlogic; orderly ExoPlayer teardown (0.17.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ Original app by [rogro82](https://github.com/rogro82/PiPup).
 Every version below has a [GitHub release](https://github.com/mhoogenbosch/PiPup/releases) with the
 full story (English and Dutch) and the APK.
 
+## [v0.17.2] — 2026-08-29 (software video decoding where the hardware decoder breaks the TV's own picture)
+Field report (Xiaomi laser projector, Android 6.0.1, Amlogic): text and snapshot popups were harmless, but
+closing a **live video popup froze the HDMI source** behind it — logcat showed the Amlogic hardware decoder
+(`OMX.amlogic.avc.decoder.awesome`) resetting its surface generation on release. A TCL on Android 8 was
+fine. On Amlogic SoCs the MediaCodec decoder and the HDMI input share one video layer, and our decoder
+being released took that layer with it. (The popup already renders into a TextureView since 0.15.1, so the
+view type is not the cause; the decoder is.)
+### Added
+- **`softwareDecoder`** (optional) on `media.video`: `true` decodes in software (the vendor hardware decoder
+  is never touched), `false` forces hardware, absent = **automatic**: software on **Android < 8** and wherever an
+  **Amlogic** H.264 decoder is present, hardware everywhere else — so nothing changes on Fire TV, Google TV
+  or Nokia boxes. Decoder fallback is enabled, so a failing software decoder still falls through to hardware.
+  Software decoding is fine for a camera sub-stream (640×480 … 720p); a 1080p main stream may be heavy on a
+  low-end projector — pick the sub-stream there. Not verified on Amlogic hardware by us (none in the fleet);
+  the flag is there so the reporter can flip it either way.
+### Changed
+- **Orderly ExoPlayer teardown** on every device: `stop()` → detach the TextureView → `release()`, instead of a
+  bare `release()` while the decoder is still bound to the surface.
+
 ## [v0.17.1] — 2026-08-29 (`/notify` and `/cancel` answer once `/state` reflects the change)
 The HTTP thread used to post the popup to the main thread and reply `200` at once. Measured on a Nokia
 8010, `/state` read ~20 ms after that reply still showed no popup; ~75 ms later it did. A client that

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "nl.rogro82.pipup"
         minSdkVersion 23
         targetSdkVersion 34
-        versionCode 44
-        versionName "0.17.1"
+        versionCode 45
+        versionName "0.17.2"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
@@ -977,7 +977,7 @@ class PiPupService : Service(), WebServer.Handler {
     /// Media summary for /state's lastPopup: {type, width, height?} or null.
     private fun mediaInfo(p: PopupProps): Map<String, Any?>? = when (val m = p.media) {
         is PopupProps.Media.Web -> mapOf("type" to "web", "width" to m.width, "height" to m.height, "poster" to (m.poster != null))
-        is PopupProps.Media.Video -> mapOf("type" to "video", "width" to m.width, "poster" to (m.poster != null))
+        is PopupProps.Media.Video -> mapOf("type" to "video", "width" to m.width, "poster" to (m.poster != null), "softwareDecoder" to m.softwareDecoder)
         is PopupProps.Media.Image -> mapOf("type" to "image", "width" to m.width)
         is PopupProps.Media.Bitmap -> mapOf("type" to "bitmap", "width" to m.width)
         null -> null

--- a/app/src/main/java/nl/rogro82/pipup/PopupProps.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PopupProps.kt
@@ -58,8 +58,12 @@ data class PopupProps(
         // `poster` (optional, video + web): URL of a still image shown immediately over the
         // stream area and faded out on the first rendered frame, so a live popup never opens
         // as an empty box while the stream connects (RTSP handshake, WebView start-up).
+        // `softwareDecoder` (optional, video): true = decode in software (bypass the vendor
+        // hardware decoder), false = always hardware, null/absent = automatic (software on
+        // Android < 8 and on Amlogic SoCs, whose hardware decoder shares the video layer with
+        // the HDMI input and freezes it when released - reported on a Xiaomi projector).
         data class Video(val uri: String, val width: Int = DEFAULT_MEDIA_WIDTH, val muted: Boolean = false,
-                         val poster: String? = null): Media()
+                         val poster: String? = null, val softwareDecoder: Boolean? = null): Media()
         @JsonIgnoreProperties(ignoreUnknown = true)
         data class Image(val uri: String, val width: Int = DEFAULT_MEDIA_WIDTH): Media()
         @JsonIgnoreProperties(ignoreUnknown = true)

--- a/app/src/main/java/nl/rogro82/pipup/PopupView.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PopupView.kt
@@ -24,7 +24,12 @@ import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.VideoSize
 import androidx.media3.common.util.UnstableApi
+import android.os.Build
+import androidx.media3.common.MimeTypes
+import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
+import androidx.media3.exoplayer.mediacodec.MediaCodecUtil
 import androidx.media3.exoplayer.rtsp.RtspMediaSource
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import com.bumptech.glide.Glide
@@ -280,6 +285,7 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
     /// defaults to muted.
     private class Video(context: Context, popup: PopupProps, val media: PopupProps.Media.Video): PopupView(context, popup) {
         private var mExoPlayer: ExoPlayer? = null
+        private var mTextureView: TextureView? = null
 
         init { create() }
 
@@ -293,6 +299,7 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
             val uri = media.uri
 
             val textureView = TextureView(context)
+            mTextureView = textureView
             // Size the TextureView (the child), never this popup view: the popup's own
             // layoutParams carry its screen position, and popup_frame is the first child of
             // the vertical layout — a fixed popup height would push the title/message out and
@@ -317,7 +324,21 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
             else
                 DefaultMediaSourceFactory(context).createMediaSource(item)
 
-            mExoPlayer = ExoPlayer.Builder(context).build().apply {
+            // Decoder choice (0.17.2). The vendor hardware decoder is the default everywhere,
+            // except where it is known to break the TV's own video: on Amlogic SoCs the
+            // MediaCodec decoder and the HDMI input share one video layer, and releasing our
+            // decoder when the popup closes froze the HDMI picture (Xiaomi projector, Android
+            // 6.0.1, OMX.amlogic.avc.decoder.awesome; the TCL on Android 8 was fine). There
+            // we prefer the software decoders (OMX.google.* / c2.android.*), which never
+            // touch that layer. `softwareDecoder` in the payload overrides the automatic rule.
+            val software = media.softwareDecoder ?: autoSoftwareDecoder()
+            Log.i(LOG_TAG, "video decoder: ${if (software) "software (preferred)" else "hardware (default)"}" +
+                " [auto=${media.softwareDecoder == null}, sdk=${Build.VERSION.SDK_INT}]")
+            val renderers = DefaultRenderersFactory(context)
+                .setEnableDecoderFallback(true)
+                .setMediaCodecSelector(if (software) SOFTWARE_FIRST_SELECTOR else MediaCodecSelector.DEFAULT)
+
+            mExoPlayer = ExoPlayer.Builder(context, renderers).build().apply {
                 setVideoTextureView(textureView)
                 if (media.muted) {
                     // no audio track at all: avoid grabbing the audio output from whatever plays
@@ -347,10 +368,44 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
         override fun destroy() {
             super.destroy()
             destroyPoster()
+            // Orderly teardown: stop decoding, detach the output surface, then release. A bare
+            // release() lets the decoder die while still bound to the surface, which is the
+            // moment a vendor pipeline (Amlogic) lost sync with the HDMI input.
             try {
-                mExoPlayer?.release()
+                mExoPlayer?.let { player ->
+                    runCatching { player.stop() }
+                    mTextureView?.let { tv -> runCatching { player.clearVideoTextureView(tv) } }
+                    player.release()
+                }
+            } catch(e: Throwable) {
+            } finally {
                 mExoPlayer = null
-            } catch(e: Throwable) {}
+                mTextureView = null
+            }
+        }
+
+        companion object {
+            /// Software decoders first, then the rest as ExoPlayer would order them; only for
+            /// video mime types (audio is disabled anyway). With decoder fallback enabled a
+            /// failing software decoder still falls through to the hardware one.
+            @UnstableApi
+            val SOFTWARE_FIRST_SELECTOR = MediaCodecSelector { mimeType, requiresSecureDecoder, requiresTunnelingDecoder ->
+                val infos = MediaCodecUtil.getDecoderInfos(mimeType, requiresSecureDecoder, requiresTunnelingDecoder)
+                if (MimeTypes.isVideo(mimeType)) infos.sortedBy { if (it.softwareOnly) 0 else 1 } else infos
+            }
+
+            /// Automatic rule: software on Android < 8 (old vendor decoders, the projector
+            /// class of devices) and wherever an Amlogic decoder is present, hardware elsewhere.
+            @UnstableApi
+            fun autoSoftwareDecoder(): Boolean {
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return true
+                return try {
+                    MediaCodecUtil.getDecoderInfos(MimeTypes.VIDEO_H264, false, false)
+                        .any { it.name.contains("amlogic", ignoreCase = true) }
+                } catch (e: Throwable) {
+                    false
+                }
+            }
         }
     }
 

--- a/readme.md
+++ b/readme.md
@@ -125,7 +125,7 @@ text, `/state`, `/notify`, `/cancel`, mDNS discovery, the overlay watchdog, and 
 |---|---|
 | Popups, TTS, buttons, styling, `/state`, screen **on** | **6.0.1+** (all) |
 | Overlay rendering | 6–7 via `TYPE_SYSTEM_ALERT` (needs the overlay app-op — the installer grants it); 8+ via `TYPE_APPLICATION_OVERLAY` |
-| **`video_url`** — `rtsp://`, HLS `.m3u8` (incl. `camera_mode: stream`), progressive http (since 0.16.0) | **6.0.1+**, via ExoPlayer rendered in a `TextureView` — composited by the GPU inside the popup, so it also shows **over video the TV is already playing** (verified on a Fire TV with a film running). RTSP uses RTP-over-TCP. Audio only with `muted: false`. Not for DRM content (irrelevant for cameras). |
+| **`video_url`** — `rtsp://`, HLS `.m3u8` (incl. `camera_mode: stream`), progressive http (since 0.16.0) | **6.0.1+**, via ExoPlayer rendered in a `TextureView` — composited by the GPU inside the popup, so it also shows **over video the TV is already playing** (verified on a Fire TV with a film running). RTSP uses RTP-over-TCP. Audio only with `muted: false`. Not for DRM content (irrelevant for cameras). On **Android < 8 and Amlogic SoCs** video is decoded in software by default (since 0.17.2) because the vendor decoder froze the HDMI input on release; `softwareDecoder` overrides. |
 | MJPEG camera streams | use **`web_url`** (or the HA integration's `camera_mode: mjpeg`), never `image_url` — `image_url` decodes a single still image and cannot render a multipart MJPEG stream (it shows only the text). For a still, point `image_url` at a snapshot such as Frigate's `/api/<cam>/latest.jpg`. |
 | Screen **off** (`POST /power?state=off`) | any version, after a one-time device-admin **or** accessibility grant (`--power` / `--accessibility`); which route works depends on the device |
 | **Silent** self-update | **12+** only. On older devices the update still works but the system shows an install confirmation the app wakes the screen for and turns into a popup with a button — one press on the remote finishes it (see [the limitation](https://github.com/mhoogenbosch/ha-pipup#the-update-button-is-silent-only-on-android-12)) |
@@ -335,6 +335,19 @@ match. If the poster fails to load nothing happens; if the stream never paints, 
 ```json
 { "video": { "uri": "rtsp://cam/sub", "width": 640, "poster": "http://frigate:5000/api/cam/latest.jpg" }}
 ```
+`softwareDecoder` (since 0.17.2, video only, default *automatic*): `true` decodes in software and never
+touches the vendor hardware decoder; `false` forces the hardware decoder; absent = automatic — software on
+**Android < 8** and wherever an **Amlogic** H.264 decoder is present, hardware everywhere else. Reason: on
+Amlogic SoCs the MediaCodec decoder and the HDMI input share one video layer, and releasing the decoder when
+the popup closed **froze the HDMI picture** behind it (Xiaomi laser projector, Android 6.0.1). Software
+decoding is fine for a camera sub-stream (640×480 … 720p); a 1080p main stream may be heavy on a low-end
+projector — use the sub-stream there. Decoder fallback is on, so a failing software decoder falls through to
+hardware. `/state.lastPopup.media.softwareDecoder` echoes the requested value (`null` = automatic).
+
+```json
+{ "video": { "uri": "rtsp://cam/sub", "width": 640, "softwareDecoder": true }}
+```
+
 
 `muted` (since 0.2.4, default `false`): plays the video/web media without audio. For web media every
 (also dynamically added) `<video>`/`<audio>` element on the page is muted, so the page never claims


### PR DESCRIPTION
## Why
Field report (Xiaomi laser projector, Android 6.0.1, Amlogic): text/snapshot popups fine, but closing a **live video popup froze the HDMI source**. Logcat: `OMX.amlogic.avc.decoder.awesome` resetting its surface generation on release. A TCL on Android 8 was fine. We already render into a TextureView (0.15.1), so the view type isn't it — on Amlogic the MediaCodec decoder and the HDMI input share one video layer, and releasing our decoder takes it down.

## Added
- `media.video.softwareDecoder`: `true` = software decoders only-first (vendor decoder untouched), `false` = hardware, absent = **auto** (software on Android < 8 or when an Amlogic H.264 decoder is present). `MediaCodecSelector` sorting `softwareOnly` first + `setEnableDecoderFallback(true)`. `/state.lastPopup.media.softwareDecoder` echoes it.

## Changed
- Teardown: `stop()` → `clearVideoTextureView()` → `release()` instead of a bare `release()`.

No behaviour change on Fire TV / Google TV / Nokia (Android ≥ 9, non-Amlogic). Not verifiable in our fleet; the reporter will test both devices. versionCode 45 / 0.17.2, changelog + readme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)