### PR TITLE
TCL: accessibility service on by default in the installers (keeps the process at adj 100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Original app by [rogro82](https://github.com/rogro82/PiPup).
 Every version below has a [GitHub release](https://github.com/mhoogenbosch/PiPup/releases) with the
 full story (English and Dutch) and the APK.
 
+## [Unreleased] — installers and docs only, ships with the next release
+### Changed
+- **`install.sh` / `install.ps1` enable the accessibility service by default on TCL Google TVs**
+  (`--no-accessibility` / `-NoAccessibility` to opt out). Finding from issue #38: a process with a
+  system-bound accessibility service sits at `oom_score_adj` 100 ("visible"), out of reach of TCL's vendor
+  guard that kills and freezes background apps — a stronger and quieter keep-alive than the activity-start
+  route (200). Measured on a TCL Google TV (Android 11) and confirmed on a second owner's set that had
+  been dropping off for weeks. The service itself stays dormant. The README's TCL section leads with it now.
+
 ## [v0.18.1] — 2026-08-29 (the built-in chime is actually audible over HDMI)
 ### Fixed
 - The 0.18.0 chime (0.42 s) played — logcat showed every frame delivered — but was inaudible on a Nokia 8010

--- a/install.ps1
+++ b/install.ps1
@@ -26,6 +26,9 @@ param(
 
     # also enable the accessibility fallback for screen off
     [switch]$Accessibility,
+    # Skip the accessibility service even on TCL, where it is enabled by default
+    # (a system-bound service keeps the process alive there).
+    [switch]$NoAccessibility,
 
     # uninstall first on a signature clash (WARNING: wipes the stable device id)
     [switch]$ForceUninstall,
@@ -135,6 +138,14 @@ foreach ($device in $Devices) {
         Write-Host '  .  no vendor auto-start op on this device (normal outside TCL)'
     } else {
         Write-Ok 'auto-start op granted (TCL)'
+        # TCL: a system-bound accessibility service is what keeps the process alive
+        # (oom_score_adj 100, out of the vendor guard's reach) - see the README's TCL section.
+        if ($NoAccessibility) {
+            Write-Host '  . TCL: accessibility keep-alive skipped (-NoAccessibility)'
+        } elseif (-not $Accessibility) {
+            Write-Host '  . TCL: enabling the accessibility service (keeps the process alive; -NoAccessibility to skip)'
+            $Accessibility = $true
+        }
     }
 
     if ($Power) {

--- a/install.sh
+++ b/install.sh
@@ -23,6 +23,7 @@ PORT=7979
 APK=""
 GRANT_POWER=0
 GRANT_ACCESSIBILITY=0
+NO_ACCESSIBILITY=0
 FORCE_UNINSTALL=0
 WAKE=0
 DEVICES=()
@@ -34,8 +35,12 @@ Usage: $0 [options] <tv-ip[:port]> [tv-ip ...]
 Options:
   --apk <file>        APK to install (default: download the latest release)
   --power             also grant device admin, so POST /power?state=off works
-  --accessibility     also enable the accessibility fallback for screen off
-                      (only needed where device admin cannot reach standby)
+  --accessibility     also enable the app's accessibility service: the screen-off
+                      fallback where device admin cannot reach standby. On TCL
+                      Google TVs this is ON BY DEFAULT, because a system-bound
+                      accessibility service is what keeps the process alive there
+                      (oom_score_adj 100, out of the vendor guard's reach)
+  --no-accessibility  do not enable it, not even on TCL
   --force-uninstall   uninstall first when the signature differs
                       (WARNING: wipes the app's stable device id, so Home Assistant
                       sees a new device)
@@ -59,6 +64,7 @@ while [ $# -gt 0 ]; do
         --apk)              APK="${2:?--apk needs a file}"; shift 2 ;;
         --power)            GRANT_POWER=1; shift ;;
         --accessibility)    GRANT_ACCESSIBILITY=1; shift ;;
+        --no-accessibility) NO_ACCESSIBILITY=1; shift ;;
         --force-uninstall)  FORCE_UNINSTALL=1; shift ;;
         --wake)             WAKE=1; shift ;;
         -h|--help)          usage; exit 0 ;;
@@ -148,6 +154,17 @@ for device in "${DEVICES[@]}"; do
         log "  · no vendor auto-start op on this device (normal outside TCL)"
     else
         ok "auto-start op granted (TCL)"
+        # TCL: the vendor guard kills and freezes background apps, and the one state
+        # it leaves alone is a process with a system-bound service. Enabling the app's
+        # (otherwise dormant) accessibility service does exactly that: oom_score_adj
+        # 100, "visible". Measured on a TCL Google TV (Android 11) and confirmed by a
+        # second owner whose TV had been dropping off for weeks (issue #38).
+        if [ "$NO_ACCESSIBILITY" -eq 1 ]; then
+            log "  · TCL: accessibility keep-alive skipped (--no-accessibility)"
+        elif [ "$GRANT_ACCESSIBILITY" -eq 0 ]; then
+            log "  · TCL: enabling the accessibility service (keeps the process alive; --no-accessibility to skip)"
+            GRANT_ACCESSIBILITY=1
+        fi
     fi
 
     if [ "$GRANT_POWER" -eq 1 ]; then

--- a/readme.md
+++ b/readme.md
@@ -165,6 +165,7 @@ Grab `install.sh` (Linux/macOS/WSL) or `install.ps1` (Windows) from the
 ```
 ./install.sh 192.168.1.10 192.168.1.11          # downloads the latest APK itself
 ./install.sh --power --apk PiPup.apk 192.168.1.10
+# TCL Google TV: the accessibility keep-alive is enabled by default (see the TCL section)
 ```
 
 It installs the APK, grants the app-ops below, starts the service and verifies over HTTP that the
@@ -222,6 +223,33 @@ TCL ships an extra guard (`com.tcl.guard`) with two separate mechanisms. Both lo
 and neither is caused by memory pressure — measured on a 1 GB set, PiPup used 26 MB PSS while the
 launcher used 119 MB and the screensaver 91 MB.
 
+**The fix that covers both: enable PiPup's accessibility service.** The installers on master do this by
+default on TCL, shipping with the first release after 0.18.1 (`--no-accessibility` / `-NoAccessibility`
+to opt out). The service itself is
+dormant — it observes nothing and the app only uses it as the screen-off fallback — but once it is
+enabled, `system_server` keeps it *bound*, and a process with a system-bound service sits at
+`oom_score_adj` **100** ("visible"): above anything the guard kills or freezes, and above the 200 the
+activity route below reaches. Measured on a TCL Google TV (Android 11):
+
+```
+$ adb shell 'P=$(pidof nl.rogro82.pipup); cat /proc/$P/oom_score_adj'
+100
+$ adb shell dumpsys activity processes | grep -A1 nl.rogro82.pipup
+  Proc #12: vis  F/S/FGS  nl.rogro82.pipup (service)
+      nl.rogro82.pipup/.PiPupAccessibilityService <= Proc{741:system/1000}
+```
+
+A second owner whose TCL had been dropping off for weeks went from 500 to 100 with this one change
+(issue #38). TCL's accessibility settings screen is a stub, so it has to be adb — and **append**, or you
+switch off every other accessibility service on the set:
+
+```
+adb shell 'cur=$(settings get secure enabled_accessibility_services); settings put secure enabled_accessibility_services "${cur:+$cur:}nl.rogro82.pipup/nl.rogro82.pipup.PiPupAccessibilityService"; settings put secure accessibility_enabled 1'
+```
+
+Like every grant it survives updates via `install.sh`, which re-applies it. The two mechanisms below are
+what you are up against without it, and how to recover a TV that is already stuck.
+
 **1. It blocks the automatic restart** of a killed service unless the app holds the vendor-specific
 `APP_AUTO_START` app-op — it logs `forbid restart Servic ... callee_does't_have_OP_AUTO_START_permission`
 and the service never comes back after a kill. The on-screen menu ("Permission Guardian" →
@@ -251,9 +279,9 @@ adb shell 'P=$(pidof nl.rogro82.pipup); grep freezer /proc/$P/cgroup; cat /proc/
 adb shell netstat -ltn | grep 7979   # frozen: Recv-Q > 0 on LISTEN, plus CLOSE_WAIT rows
 ```
 
-Incoming traffic does not thaw the app; only bringing it to the foreground does. **What keeps it
-running is `oom_score_adj` 200, and the app only reaches that when it is started from a foreground
-context**, i.e. via the activity:
+Incoming traffic does not thaw the app; only bringing it to the foreground does. Without the
+accessibility service above, **what keeps it running is `oom_score_adj` 200, and the app only reaches
+that when it is started from a foreground context**, i.e. via the activity:
 
 ```
 adb shell input keyevent KEYCODE_WAKEUP   # only needed while the screensaver is on


### PR DESCRIPTION
Follow-up to #38.

- `install.sh` / `install.ps1`: when the TCL `android:auto_start` op is present, enable PiPup's accessibility service by default (`--no-accessibility` / `-NoAccessibility` to opt out). A system-bound service keeps the process at `oom_score_adj` 100 ("visible"), outside the vendor guard's kill/freeze — measured on my TCL Google TV (Android 11) and confirmed by the #38 reporter (500 → 100).
- README TCL section now leads with this, incl. the append-only adb line and the `dumpsys` evidence.
- CHANGELOG: `Unreleased` section (installers are release assets; ships with the next release).

No app code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)