### PR TITLE
Compact buttons (buttonSize) + entrance/exit animations (0.19.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,17 @@ Original app by [rogro82](https://github.com/rogro82/PiPup).
 Every version below has a [GitHub release](https://github.com/mhoogenbosch/PiPup/releases) with the
 full story (English and Dutch) and the APK.
 
-## [Unreleased] — installers and docs only, ships with the next release
+## [v0.19.0] — 2026-08-31 (compact buttons; entrance/exit animations; TCL keep-alive by default)
+Requested (#40): smaller popups were impossible with three buttons dictating the minimum width, and an
+entrance animation was wished for.
+### Added
+- **`buttonSize`** (sp): scales the button text and its padding together, so a popup with buttons can be
+  genuinely small. Without the field the classic look is unchanged.
+- **`animation`**: `fade`, `slide_left`, `slide_right`, `slide_top`, `slide_bottom` — plays when a popup is
+  **built**; an update-in-place of the same popup deliberately does not re-animate (a camera popup
+  re-notified every few seconds must not keep sliding in). A popup that **expires naturally** animates out
+  the same way; a replace, `/cancel` or button press still tears down instantly, so 0.17.1's "200 = gone
+  from `/state`" contract holds. Unknown names show instantly. `/state.lastPopup.animation` echoes it.
 ### Changed
 - **`install.sh` / `install.ps1` enable the accessibility service by default on TCL Google TVs**
   (`--no-accessibility` / `-NoAccessibility` to opt out). Finding from issue #38: a process with a

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "nl.rogro82.pipup"
         minSdkVersion 23
         targetSdkVersion 34
-        versionCode 47
-        versionName "0.18.1"
+        versionCode 48
+        versionName "0.19.0"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
@@ -589,7 +589,13 @@ class PiPupService : Service(), WebServer.Handler {
         // duration <= 0 means: show until /cancel or until replaced
         if (!popup.indefinite) {
             mHandler.postDelayed({
-                removePopup(true)
+                // Natural expiry is the one removal nobody is waiting on, so it may
+                // animate (0.19.0); every other path (replace, /cancel, buttons) tears
+                // down at once. If a new popup lands mid-animation, createPopup's own
+                // removePopup wins and the animation's end action becomes a no-op.
+                val view = mPopup
+                if (view != null) view.animateOut { removePopup(true) }
+                else removePopup(true)
             }, popup.duration * 1000L) // 1000L: an Int*Int product overflows past ~24.8 days
                                         // and a negative delay removes the popup instantly
         }
@@ -756,6 +762,8 @@ class PiPupService : Service(), WebServer.Handler {
             mShownAt = SystemClock.elapsedRealtime()
             mPopupsShown.incrementAndGet()
 
+            mPopup?.animateIn()
+
             if (!popup.tts.isNullOrBlank()) {
                 speak(popup.tts, popup.ttsLanguage)
             }
@@ -854,6 +862,7 @@ class PiPupService : Service(), WebServer.Handler {
                 "media" to mediaInfo(last),
                 "tts" to !last.tts.isNullOrBlank(),
                 "sound" to !last.sound.isNullOrBlank(),
+                "animation" to last.animation,
                 "buttons" to last.buttons.size,
                 // time to first rendered frame (video/web); null while not yet painted or n/a
                 "firstFrameMs" to mLastFirstFrameMs,
@@ -1199,6 +1208,7 @@ class PiPupService : Service(), WebServer.Handler {
                                             cornerRadius = params["cornerRadius"]?.toFloatOrNull(),
                                             showProgress = params["showProgress"]?.toBoolean() ?: false,
                                             dismissScreensaver = params["dismissScreensaver"]?.toBoolean() ?: true,
+                                            animation = params["animation"],
                                             sound = params["sound"],
                                             soundVolume = params["soundVolume"]?.toFloatOrNull()
                                         )

--- a/app/src/main/java/nl/rogro82/pipup/PopupProps.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PopupProps.kt
@@ -40,7 +40,12 @@ data class PopupProps(
     // 0.18.0: optional notification sound when a popup is (newly) shown: "default" = built-in
     // chime, or a URL to an audio clip. Not replayed on an update-in-place of the same popup.
     val sound: String? = null,
-    val soundVolume: Float? = null        // 0..1; device notification volume when omitted
+    val soundVolume: Float? = null,       // 0..1; device notification volume when omitted
+    // 0.19.0: button text size in sp (padding scales along); null = the classic look
+    val buttonSize: Float? = null,
+    // 0.19.0: entrance animation (and exit on natural expiry): fade, slide_left,
+    // slide_right, slide_top, slide_bottom; null/none = appear instantly (classic).
+    val animation: String? = null
 ) {
     val indefinite: Boolean
         get() = duration <= 0

--- a/app/src/main/java/nl/rogro82/pipup/PopupView.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PopupView.kt
@@ -218,7 +218,20 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
                     isFocusable = true
                     isAllCaps = false
                     setTextColor(Color.WHITE)
-                    setPadding(36, 16, 36, 16)
+                    // Compact buttons (0.19.0): an explicit buttonSize scales the text and
+                    // the padding with it; without it the classic look stays byte-identical.
+                    // 14 sp is the platform Button default the classic padding was tuned for.
+                    val size = popup.buttonSize
+                    if (size != null && size > 0) {
+                        textSize = size
+                        val h = (size / 14f * 36).toInt().coerceAtLeast(8)
+                        val v = (size / 14f * 16).toInt().coerceAtLeast(4)
+                        setPadding(h, v, h, v)
+                        minWidth = 0; minimumWidth = 0
+                        minHeight = 0; minimumHeight = 0
+                    } else {
+                        setPadding(36, 16, 36, 16)
+                    }
                     stateListAnimator = null   // the platform one would fight our scale
                     background = buttonBackground()
                     setOnClickListener { onButton?.invoke(btn) }
@@ -260,6 +273,58 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
             mProgressAnimator?.cancel()
         } catch (_: Throwable) {}
         mProgressAnimator = null
+    }
+
+    /// Entrance animation (0.19.0). Runs once per *build*: an update-in-place reuses
+    /// the view and never comes back here, so a re-notified popup does not keep
+    /// sliding in. Unknown names fall back to appearing instantly.
+    fun animateIn() {
+        when (popup.animation?.lowercase()) {
+            null, "", "none" -> return
+            "fade" -> { alpha = 0f; animate().alpha(1f).setDuration(220).start() }
+            "slide_left" -> slideIn(-1f, 0f)
+            "slide_right" -> slideIn(1f, 0f)
+            "slide_top" -> slideIn(0f, -1f)
+            "slide_bottom" -> slideIn(0f, 1f)
+            else -> Log.w(LOG_TAG, "unknown animation '${popup.animation}' — showing instantly")
+        }
+    }
+
+    private fun slideIn(dx: Float, dy: Float) {
+        // Distance based on the popup's own size once measured; a fixed 300 px
+        // fallback covers the first frame before layout.
+        post {
+            translationX = dx * (if (width > 0) width.toFloat() else 300f)
+            translationY = dy * (if (height > 0) height.toFloat() else 300f)
+            alpha = 0.6f
+            animate().translationX(0f).translationY(0f).alpha(1f).setDuration(220).start()
+        }
+        // hide the pre-layout frame at its final position
+        translationX = dx * 3000f; translationY = dy * 3000f
+    }
+
+    /// Exit animation for a popup that expires naturally; [onEnd] performs the real
+    /// removal. Callers that replace or cancel a popup skip this and tear down at
+    /// once — /cancel's "200 = gone from /state" contract (0.17.1) stays intact.
+    fun animateOut(onEnd: () -> Unit) {
+        when (popup.animation?.lowercase()) {
+            null, "", "none" -> { onEnd(); return }
+        }
+        val dx: Float; val dy: Float
+        when (popup.animation?.lowercase()) {
+            "slide_left" -> { dx = -1f; dy = 0f }
+            "slide_right" -> { dx = 1f; dy = 0f }
+            "slide_top" -> { dx = 0f; dy = -1f }
+            "slide_bottom" -> { dx = 0f; dy = 1f }
+            else -> { dx = 0f; dy = 0f } // fade
+        }
+        animate()
+            .translationX(dx * width)
+            .translationY(dy * height)
+            .alpha(0f)
+            .setDuration(180)
+            .withEndAction { runCatching(onEnd) }
+            .start()
     }
 
     private class Default(context: Context, popup: PopupProps) : PopupView(context, popup) {

--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,11 @@ streams) on your TV from your home-automation system, for **as long as you want*
   app ends it before showing the popup (the same wake path as `/power`), because on several Android
   builds the dream layer covers app overlays and Android 12+ lets it hide them. `dismissScreensaver: false`
   keeps the screensaver; `/state.dreaming` reports the current state.
+- **Compact buttons** (since 0.19.0) — `buttonSize` (sp) scales button text and padding together, so a
+  popup with buttons can be small; omit it for the classic look.
+- **Entrance/exit animations** (since 0.19.0) — `animation: fade | slide_left | slide_right | slide_top |
+  slide_bottom`, played when the popup is built and again (reversed) when it expires naturally. An
+  update-in-place never re-animates, and replace/`/cancel` still remove instantly.
 - **Notification sound** (since 0.18.0) — `sound: "default"` plays a built-in chime when a popup is newly
   shown, or give a URL to your own clip; `soundVolume` (0–1). Not replayed on an update-in-place.
 - **Poster** (since 0.17.0) — an optional `poster` (image URL) on `video` and `web` media: a still
@@ -397,6 +402,13 @@ path, which on some Fire TVs briefly renegotiates HDMI audio.
 ```json
 { "id": "doorbell", "title": "Front door", "sound": "default", "soundVolume": 0.8 }
 ```
+
+`buttonSize` (since 0.19.0, sp): scales the popup buttons' text and padding together. Without it the
+buttons look exactly as before.
+
+`animation` (since 0.19.0, default none): `fade`, `slide_left`, `slide_right`, `slide_top` or
+`slide_bottom`. Plays when the popup is built; an update-in-place of the same popup does not re-animate.
+A naturally expiring popup animates out the same way; replace and `/cancel` remove instantly.
 
 `muted` (since 0.2.4, default `false`): plays the video/web media without audio. For web media every
 (also dynamically added) `<video>`/`<audio>` element on the page is muted, so the page never claims


### PR DESCRIPTION
Implements #40 items 1 and 2 (item 3, stacking, stays parked — see the issue).

- **`buttonSize`** (sp): button text + padding scale together; min-width/height cleared so three small buttons no longer dictate the popup width. Absent = classic look, byte-identical.
- **`animation`**: `fade` / `slide_left` / `slide_right` / `slide_top` / `slide_bottom`. Runs on **build** (update-in-place never re-animates) and reversed on **natural expiry** only — replace, `/cancel` and button presses tear down instantly, preserving 0.17.1's "200 = gone from `/state`" contract. Unknown names log a warning and show instantly. Echoed in `/state.lastPopup.animation`; multipart accepts `animation` too.

Smoke-tested on a Fire TV (Android 9): fade, slide_bottom with `buttonSize: 9` and 3 buttons, unknown animation name, natural expiry — `/state` clean afterwards, `watchdogCleanups` 0, no runtime errors. versionCode 48 / 0.19.0; the changelog folds in the pending TCL-installer section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)