### PR TITLE
Unclip button corners; padding field; surface synchronous install errors (0.19.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ Original app by [rogro82](https://github.com/rogro82/PiPup).
 Every version below has a [GitHub release](https://github.com/mhoogenbosch/PiPup/releases) with the
 full story (English and Dutch) and the APK.
 
+## [v0.19.1] — 2026-08-31 (button corners unclipped; `padding`; install errors visible in /state)
+Field report with a screenshot (#40 follow-up) and a stuck self-update with an empty `update.error` (#41).
+### Added
+- **`padding`** (px): the popup's outer margin around content; the classic look is 20, `0` gives a
+  near-borderless popup.
+### Fixed
+- **The buttons' bottom rounded corners were clipped** against the popup border: the button row had no
+  bottom margin, and the popup clipped its children (which also trimmed the focus scale-up and slide
+  animations at the edges). Bottom margin added; the popup and the button row no longer clip children.
+- **A synchronous self-update failure was invisible.** `installLatest`'s early failures — a failed download
+  (HTTP error or exception: DNS, TLS/old root store) or a `PackageInstaller` commit exception — only went to
+  logcat; `/state.update.error` stayed `null` and the update just seemed to do nothing (exactly the #41
+  report: Install pressed, nothing happened, `error: null`). Those paths now set `update.error`, and a
+  successful commit clears it.
+
 ## [v0.19.0] — 2026-08-31 (compact buttons; entrance/exit animations; TCL keep-alive by default)
 Requested (#40): smaller popups were impossible with three buttons dictating the minimum width, and an
 entrance animation was wished for.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "nl.rogro82.pipup"
         minSdkVersion 23
         targetSdkVersion 34
-        versionCode 48
-        versionName "0.19.0"
+        versionCode 49
+        versionName "0.19.1"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
@@ -1209,6 +1209,7 @@ class PiPupService : Service(), WebServer.Handler {
                                             showProgress = params["showProgress"]?.toBoolean() ?: false,
                                             dismissScreensaver = params["dismissScreensaver"]?.toBoolean() ?: true,
                                             animation = params["animation"],
+                                            padding = params["padding"]?.toIntOrNull(),
                                             sound = params["sound"],
                                             soundVolume = params["soundVolume"]?.toFloatOrNull()
                                         )

--- a/app/src/main/java/nl/rogro82/pipup/PopupProps.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PopupProps.kt
@@ -43,6 +43,9 @@ data class PopupProps(
     val soundVolume: Float? = null,       // 0..1; device notification volume when omitted
     // 0.19.0: button text size in sp (padding scales along); null = the classic look
     val buttonSize: Float? = null,
+    // 0.19.1: outer padding of the popup in px (the black margin around content);
+    // null = the classic 20 px. 0 gives a near-borderless look.
+    val padding: Int? = null,
     // 0.19.0: entrance animation (and exit on natural expiry): fade, slide_left,
     // slide_right, slide_top, slide_bottom; null/none = appear instantly (classic).
     val animation: String? = null

--- a/app/src/main/java/nl/rogro82/pipup/PopupView.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PopupView.kt
@@ -128,7 +128,12 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
             minimumWidth = 240
         }
 
-        setPadding(20,20,20,20)
+        // 0.19.1: configurable outer padding; the focus scale-up of buttons and the
+        // slide animations may paint outside their box, so never clip children.
+        val pad = popup.padding ?: 20
+        setPadding(pad, pad, pad, pad)
+        clipChildren = false
+        clipToPadding = false
 
         val title = findViewById<TextView>(R.id.popup_title)
         val message = findViewById<TextView>(R.id.popup_message)
@@ -210,6 +215,8 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
             val row = LinearLayout(context).apply {
                 orientation = HORIZONTAL
                 gravity = Gravity.CENTER
+                clipChildren = false
+                clipToPadding = false
             }
             var firstButton: Button? = null
             popup.buttons.forEach { btn ->
@@ -242,7 +249,9 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
                 }
                 if (firstButton == null) firstButton = button
                 row.addView(button, LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT).apply {
-                    setMargins(10, 10, 10, 0)
+                    // 0.19.1: bottom margin was 0, which clipped the buttons' rounded
+                    // corners against the popup border (field report with a screenshot).
+                    setMargins(10, 10, 10, 6)
                 })
             }
             addView(row, LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT))

--- a/app/src/main/java/nl/rogro82/pipup/UpdateManager.kt
+++ b/app/src/main/java/nl/rogro82/pipup/UpdateManager.kt
@@ -159,6 +159,7 @@ object UpdateManager {
             if (conn.responseCode != 200) {
                 return "download failed: HTTP ${conn.responseCode}".also {
                     Log.w(LOG_TAG, it)
+                    lastError = it   // 0.19.1: synchronous failures were invisible in /state
                     installStartedAt.set(0)
                 }
             }
@@ -186,11 +187,13 @@ object UpdateManager {
                 session.commit(pendingIntent(context, sessionId).intentSender)
             }
             Log.i(LOG_TAG, "Update session $sessionId committed for v$latestVersion")
+            lastError = null
             null
         } catch (ex: Throwable) {
             installStartedAt.set(0)
             "install failed: ${ex.message ?: ex.javaClass.simpleName}".also {
                 Log.e(LOG_TAG, it, ex)
+                lastError = it   // 0.19.1: a download/commit exception now shows in /state
             }
         }
     }

--- a/readme.md
+++ b/readme.md
@@ -403,6 +403,9 @@ path, which on some Fire TVs briefly renegotiates HDMI audio.
 { "id": "doorbell", "title": "Front door", "sound": "default", "soundVolume": 0.8 }
 ```
 
+`padding` (since 0.19.1, px, default 20): the popup's outer margin around content; `0` gives a
+near-borderless look.
+
 `buttonSize` (since 0.19.0, sp): scales the popup buttons' text and padding together. Without it the
 buttons look exactly as before.
 


### PR DESCRIPTION
Follow-ups from #40 (screenshot) and #41 (empty `update.error`).

- **Fixed:** button row had no bottom margin and the popup clipped children → bottom rounded corners cut off; also trimmed the focus scale-up and slide animations at the edges. Margin added, `clipChildren/clipToPadding = false` on popup + row.
- **Added:** `padding` (px, default 20; `0` = near-borderless) — requested in #40's follow-up.
- **Fixed:** synchronous `installLatest` failures (download HTTP/exception — think DNS/TLS/old root store on Android 6 — or a commit exception) only reached logcat; `/state.update.error` stayed `null`, which is exactly what #41's dump shows. They now set `update.error`; a successful commit clears it.

Smoke-tested on a Fire TV: `padding: 6` + `buttonSize: 9` + 3 buttons + slide_bottom, clean expiry, watchdog 0. versionCode 49 / 0.19.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)