### PR TITLE
Compact buttons: scale the margins along with buttonSize (0.19.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Original app by [rogro82](https://github.com/rogro82/PiPup).
 Every version below has a [GitHub release](https://github.com/mhoogenbosch/PiPup/releases) with the
 full story (English and Dutch) and the APK.
 
+## [v0.19.2] — 2026-08-31 (compact buttons: the margins scale along)
+### Fixed
+- With `buttonSize` set, the margins **around** the buttons (including the gap between the media frame and
+  the button row) stayed at the classic size while the buttons themselves shrank — a compact popup carried a
+  full-size gap above its buttons. The margins now scale with the same factor as the button padding; the
+  classic look (no `buttonSize`) is unchanged.
+
 ## [v0.19.1] — 2026-08-31 (button corners unclipped; `padding`; install errors visible in /state)
 Field report with a screenshot (#40 follow-up) and a stuck self-update with an empty `update.error` (#41).
 ### Added

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "nl.rogro82.pipup"
         minSdkVersion 23
         targetSdkVersion 34
-        versionCode 49
-        versionName "0.19.1"
+        versionCode 50
+        versionName "0.19.2"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/app/src/main/java/nl/rogro82/pipup/PopupView.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PopupView.kt
@@ -212,6 +212,12 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
         // focused/unfocused background plus a small scale bump on focus, and the
         // first one takes focus so there is an indicator from the start.
         if (popup.buttons.isNotEmpty()) {
+            // 0.19.2: with an explicit buttonSize the margins around the buttons scale
+            // with the same factor as their padding, so a compact popup is compact all
+            // the way to the row above (field report: the gap between the media frame
+            // and the buttons stayed at the classic size). Classic look unchanged.
+            val marginScale = popup.buttonSize?.takeIf { it > 0 }?.div(14f) ?: 1f
+            fun m(base: Int) = (base * marginScale).toInt().coerceAtLeast(2)
             val row = LinearLayout(context).apply {
                 orientation = HORIZONTAL
                 gravity = Gravity.CENTER
@@ -251,7 +257,7 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
                 row.addView(button, LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT).apply {
                     // 0.19.1: bottom margin was 0, which clipped the buttons' rounded
                     // corners against the popup border (field report with a screenshot).
-                    setMargins(10, 10, 10, 6)
+                    setMargins(m(10), m(10), m(10), m(6))
                 })
             }
             addView(row, LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT))


### PR DESCRIPTION
#40 follow-up: the gap between the media frame and the button row stayed classic-sized on a compact popup. Margins now scale with the same `buttonSize/14` factor as the button padding (floor 2 px); no `buttonSize` = unchanged. Smoke-tested on a Fire TV (padding 6 + buttonSize 9 + 3 buttons, clean expiry, watchdog 0). versionCode 50 / 0.19.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)