### PR TITLE
Updater TLS: system store + bundled ISRG Root X1 (0.19.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Original app by [rogro82](https://github.com/rogro82/PiPup).
 Every version below has a [GitHub release](https://github.com/mhoogenbosch/PiPup/releases) with the
 full story (English and Dutch) and the APK.
 
+## [v0.19.3] — 2026-08-31 (self-update works on Android 6: ISRG Root X1 bundled)
+### Fixed
+- **Self-update failed on Android 6 with "Trust anchor for certification path not found" (#41).** GitHub's
+  release assets live on `*.githubusercontent.com`, whose TLS chain anchors on ISRG Root X1 (Let's Encrypt) —
+  a root Android only ships from 7.1.1, which is why the update *check* (api.github.com, USERTrust root)
+  succeeded while the *download* failed. The updater's connections now trust the system store **plus** the
+  bundled ISRG Root X1, with full chain validation (no trust-all anywhere); on modern devices nothing
+  changes. Integrity stays double-locked regardless: the platform refuses an update APK with a different
+  signing certificate or a lower versionCode.
+
 ## [v0.19.2] — 2026-08-31 (compact buttons: the margins scale along)
 ### Fixed
 - With `buttonSize` set, the margins **around** the buttons (including the gap between the media frame and

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "nl.rogro82.pipup"
         minSdkVersion 23
         targetSdkVersion 34
-        versionCode 50
-        versionName "0.19.2"
+        versionCode 51
+        versionName "0.19.3"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/app/src/main/java/nl/rogro82/pipup/UpdateManager.kt
+++ b/app/src/main/java/nl/rogro82/pipup/UpdateManager.kt
@@ -6,6 +6,14 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.PackageInstaller
+import java.security.KeyStore
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+import javax.net.ssl.HttpsURLConnection
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLSocketFactory
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509TrustManager
 import android.os.Build
 import android.util.Log
 import androidx.core.content.ContextCompat
@@ -98,6 +106,7 @@ object UpdateManager {
     fun check(): Boolean {
         return try {
             val conn = (URL(RELEASES_URL).openConnection() as HttpURLConnection).apply {
+                applyUpdaterTls(this)
                 connectTimeout = NET_TIMEOUT_MS
                 readTimeout = NET_TIMEOUT_MS
                 setRequestProperty("Accept", "application/vnd.github+json")
@@ -137,6 +146,65 @@ object UpdateManager {
     /// Returns an error message, or null on success
     /// (success here means "handed to the installer": the actual result arrives
     /// asynchronously in the install receiver).
+    /// TLS for the updater's own connections: the system trust store PLUS ISRG Root X1.
+    ///
+    /// GitHub's *release assets* live on `*.githubusercontent.com`, whose chain anchors on
+    /// ISRG Root X1 (Let's Encrypt) — a root Android only ships from 7.1.1. On Android 6
+    /// the update check succeeds (api.github.com anchors on USERTrust, which 6 has) but the
+    /// download dies with "Trust anchor for certification path not found" (#41, Xiaomi
+    /// projector). Bundling that one public root and accepting system-or-ISRG restores the
+    /// self-update there with full chain validation — no trust-all anywhere. Integrity is
+    /// double-locked anyway: the platform refuses an update APK whose signing certificate
+    /// differs or whose versionCode is lower. Falls back to the default factory when
+    /// anything in the setup throws, so modern devices can never be worse off.
+    private val legacySafeSocketFactory: SSLSocketFactory? by lazy {
+        try {
+            val cf = CertificateFactory.getInstance("X.509")
+            val isrg = cf.generateCertificate(ISRG_ROOT_X1_PEM.byteInputStream()) as X509Certificate
+
+            fun managerFor(keyStore: KeyStore?): X509TrustManager {
+                val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+                tmf.init(keyStore)
+                return tmf.trustManagers.filterIsInstance<X509TrustManager>().first()
+            }
+
+            val system = managerFor(null) // null = the platform's default trust store
+            val extra = managerFor(KeyStore.getInstance(KeyStore.getDefaultType()).apply {
+                load(null, null)
+                setCertificateEntry("isrg-root-x1", isrg)
+            })
+
+            val composite = object : X509TrustManager {
+                override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String) =
+                    system.checkClientTrusted(chain, authType)
+
+                override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) {
+                    try {
+                        system.checkServerTrusted(chain, authType)
+                    } catch (ex: java.security.cert.CertificateException) {
+                        extra.checkServerTrusted(chain, authType) // full validation against ISRG Root X1
+                    }
+                }
+
+                override fun getAcceptedIssuers(): Array<X509Certificate> =
+                    system.acceptedIssuers + extra.acceptedIssuers
+            }
+
+            SSLContext.getInstance("TLS").apply {
+                init(null, arrayOf(composite), null)
+            }.socketFactory
+        } catch (ex: Throwable) {
+            Log.w(LOG_TAG, "legacy TLS factory unavailable, using platform default: ${ex.message}")
+            null
+        }
+    }
+
+    /// Apply the updater trust store to a connection (no-op for plain http and on failure).
+    private fun applyUpdaterTls(conn: HttpURLConnection) {
+        val factory = legacySafeSocketFactory ?: return
+        (conn as? HttpsURLConnection)?.sslSocketFactory = factory
+    }
+
     fun installLatest(context: Context): String? {
         val url = downloadUrl ?: return "no download URL (run a check first)"
         val now = android.os.SystemClock.elapsedRealtime()
@@ -151,6 +219,7 @@ object UpdateManager {
 
         return try {
             val conn = (URL(url).openConnection() as HttpURLConnection).apply {
+                applyUpdaterTls(this)
                 connectTimeout = NET_TIMEOUT_MS
                 readTimeout = 60000
                 instanceFollowRedirects = true
@@ -272,4 +341,41 @@ object UpdateManager {
         }
         return false
     }
+
+    /// ISRG Root X1 (Let's Encrypt), self-signed, valid until 2035-06-04. Public root
+    /// certificate, verified against the published SHA-256 fingerprint
+    /// 96:BC:EC:06:26:49:76:F3:74:60:77:9A:CF:28:C5:A7:CF:E8:A3:C0:AA:E1:1A:8F:FC:EE:05:C0:BD:DF:08:C6.
+    private const val ISRG_ROOT_X1_PEM = """
+-----BEGIN CERTIFICATE-----
+MIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAw
+TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh
+cmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMTUwNjA0MTEwNDM4
+WhcNMzUwNjA0MTEwNDM4WjBPMQswCQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJu
+ZXQgU2VjdXJpdHkgUmVzZWFyY2ggR3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBY
+MTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAK3oJHP0FDfzm54rVygc
+h77ct984kIxuPOZXoHj3dcKi/vVqbvYATyjb3miGbESTtrFj/RQSa78f0uoxmyF+
+0TM8ukj13Xnfs7j/EvEhmkvBioZxaUpmZmyPfjxwv60pIgbz5MDmgK7iS4+3mX6U
+A5/TR5d8mUgjU+g4rk8Kb4Mu0UlXjIB0ttov0DiNewNwIRt18jA8+o+u3dpjq+sW
+T8KOEUt+zwvo/7V3LvSye0rgTBIlDHCNAymg4VMk7BPZ7hm/ELNKjD+Jo2FR3qyH
+B5T0Y3HsLuJvW5iB4YlcNHlsdu87kGJ55tukmi8mxdAQ4Q7e2RCOFvu396j3x+UC
+B5iPNgiV5+I3lg02dZ77DnKxHZu8A/lJBdiB3QW0KtZB6awBdpUKD9jf1b0SHzUv
+KBds0pjBqAlkd25HN7rOrFleaJ1/ctaJxQZBKT5ZPt0m9STJEadao0xAH0ahmbWn
+OlFuhjuefXKnEgV4We0+UXgVCwOPjdAvBbI+e0ocS3MFEvzG6uBQE3xDk3SzynTn
+jh8BCNAw1FtxNrQHusEwMFxIt4I7mKZ9YIqioymCzLq9gwQbooMDQaHWBfEbwrbw
+qHyGO0aoSCqI3Haadr8faqU9GY/rOPNk3sgrDQoo//fb4hVC1CLQJ13hef4Y53CI
+rU7m2Ys6xt0nUW7/vGT1M0NPAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNV
+HRMBAf8EBTADAQH/MB0GA1UdDgQWBBR5tFnme7bl5AFzgAiIyBpY9umbbjANBgkq
+hkiG9w0BAQsFAAOCAgEAVR9YqbyyqFDQDLHYGmkgJykIrGF1XIpu+ILlaS/V9lZL
+ubhzEFnTIZd+50xx+7LSYK05qAvqFyFWhfFQDlnrzuBZ6brJFe+GnY+EgPbk6ZGQ
+3BebYhtF8GaV0nxvwuo77x/Py9auJ/GpsMiu/X1+mvoiBOv/2X/qkSsisRcOj/KK
+NFtY2PwByVS5uCbMiogziUwthDyC3+6WVwW6LLv3xLfHTjuCvjHIInNzktHCgKQ5
+ORAzI4JMPJ+GslWYHb4phowim57iaztXOoJwTdwJx4nLCgdNbOhdjsnvzqvHu7Ur
+TkXWStAmzOVyyghqpZXjFaH3pO3JLF+l+/+sKAIuvtd7u+Nxe5AW0wdeRlN8NwdC
+jNPElpzVmbUq4JUagEiuTDkHzsxHpFKVK7q4+63SM1N95R1NbdWhscdCb+ZAJzVc
+oyi3B43njTOQ5yOf+1CceWxG1bQVs5ZufpsMljq4Ui0/1lvh+wjChP4kqKOJ2qxq
+4RgqsahDYVvTH9w7jXbyLeiNdd8XM2w9U/t7y0Ff/9yi0GE44Za4rF2LN9d11TPA
+mRGunUHBcnWEvgJBQl9nJEiU0Zsnvgc/ubhPgXRR4Xq37Z0j4r7g1SgEEzwxA57d
+emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
+-----END CERTIFICATE-----
+"""
 }

--- a/readme.md
+++ b/readme.md
@@ -135,6 +135,7 @@ text, `/state`, `/notify`, `/cancel`, mDNS discovery, the overlay watchdog, and 
 | Capability | Works on |
 |---|---|
 | Popups, TTS, buttons, styling, `/state`, screen **on** | **6.0.1+** (all) |
+| **Self-update** | **6.0.1+** since 0.19.3 (bundles ISRG Root X1 — Android < 7.1.1 lacks the Let's Encrypt root that GitHub's download hosts use) |
 | Overlay rendering | 6–7 via `TYPE_SYSTEM_ALERT` (needs the overlay app-op — the installer grants it); 8+ via `TYPE_APPLICATION_OVERLAY` |
 | **`video_url`** — `rtsp://`, HLS `.m3u8` (incl. `camera_mode: stream`), progressive http (since 0.16.0) | **6.0.1+**, via ExoPlayer rendered in a `TextureView` — composited by the GPU inside the popup, so it also shows **over video the TV is already playing** (verified on a Fire TV with a film running). RTSP uses RTP-over-TCP. Audio only with `muted: false`. Not for DRM content (irrelevant for cameras). On **Android < 8 and Amlogic SoCs** video is decoded in software by default (since 0.17.2) because the vendor decoder froze the HDMI input on release; `softwareDecoder` overrides. |
 | MJPEG camera streams | use **`web_url`** (or the HA integration's `camera_mode: mjpeg`), never `image_url` — `image_url` decodes a single still image and cannot render a multipart MJPEG stream (it shows only the text). For a still, point `image_url` at a snapshot such as Frigate's `/api/<cam>/latest.jpg`. |


### PR DESCRIPTION
Fixes #41.

The reporter's `/state` (thanks to 0.19.1's error surfacing) showed `install failed: java.security.cert.CertPathValidatorException: Trust anchor for certification path not found` on Android 6.0.1. Verified cause: `api.github.com`/`github.com` anchor on **USERTrust** (present on Android 6 → the check works), but release assets on `*.githubusercontent.com` anchor on **ISRG Root X1**, which Android ships only from 7.1.1 → the download fails.

Fix: the updater's connections use a composite trust manager — system store first, bundled ISRG Root X1 (public root, fingerprint-verified, valid to 2035) as fallback — with full chain validation in both paths; no trust-all. Any setup failure falls back to the platform default factory, so modern devices can never be worse off. The platform's signing-certificate and versionCode checks remain the integrity backstop for the installed APK.

Smoke: check path exercised through the new factory on a Fire TV (Android 9), `update.error: null`. The real proof is the reporter's Android 6 projector on the next release. versionCode 51 / 0.19.3; README's supported-devices table updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)