### PR TITLE
Web popups: the poster fades when the video actually plays (0.20.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Original app by [rogro82](https://github.com/rogro82/PiPup).
 Every version below has a [GitHub release](https://github.com/mhoogenbosch/PiPup/releases) with the
 full story (English and Dutch) and the APK.
 
+## [v0.20.0] — 2026-08-31 (the poster waits for the video on web popups)
+### Changed
+- **On a `web_url` popup the poster now fades when the page's *video* actually plays**, not when the page
+  paints. For an MJPEG/snapshot page nothing changes (its paint *is* the image — a watcher reports
+  "no video" within ~0.4 s). But a player page such as go2rtc's WebRTC viewer paints its shell seconds
+  before the stream flows, and 0.19.x faded the poster at that paint — leaving a black hole until WebRTC
+  connected. The watcher also looks inside shadow DOM (go2rtc's `video-rtc` element) and a hard 8 s cap
+  keeps a broken page from pinning the poster forever. This makes **WebRTC + poster** the best camera
+  route on TVs: instant still, then near-realtime video (sub-second lag, full frame rate), with the slow
+  WebRTC start-up fully masked. `firstFrameMs` now measures to actual playback on such pages.
+
 ## [v0.19.3] — 2026-08-31 (self-update works on Android 6: ISRG Root X1 bundled)
 ### Fixed
 - **Self-update failed on Android 6 with "Trust anchor for certification path not found" (#41).** GitHub's

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "nl.rogro82.pipup"
         minSdkVersion 23
         targetSdkVersion 34
-        versionCode 51
-        versionName "0.19.3"
+        versionCode 52
+        versionName "0.20.0"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/app/src/main/java/nl/rogro82/pipup/PopupView.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PopupView.kt
@@ -571,17 +571,33 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
                     mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
                 }
                 webViewClient = object : WebViewClient() {
-                    // First visible paint of the page. Used for the poster hand-over and
-                    // the firstFrameMs measurement. Deliberately NOT onPageFinished: that
-                    // fires when everything has loaded, and an MJPEG stream never finishes.
+                    // First visible paint of the page (deliberately NOT onPageFinished:
+                    // that never fires for an MJPEG stream). For a plain page (MJPEG,
+                    // snapshot) this IS the first image — but a page that hosts a <video>
+                    // (go2rtc's WebRTC player) paints its shell seconds before the video
+                    // flows, and fading the poster here left a black hole until the
+                    // stream connected (0.19.x). So: inject a watcher; it reports
+                    // "playing" once a video actually renders frames, or "novideo" when
+                    // the page has no video element — and only then the poster fades.
                     override fun onPageCommitVisible(view: WebView?, url: String?) {
-                        onStreamFirstFrame()
+                        view?.evaluateJavascript(VIDEO_WATCH_JS, null)
+                        // Hard cap: a broken page must not pin the poster forever; a
+                        // stale snapshot is still better than black, so fade late.
+                        view?.postDelayed({ onStreamFirstFrame() }, POSTER_FADE_CAP_MS)
                     }
                     override fun onPageFinished(view: WebView?, url: String?) {
                         // mute every (also dynamically added) media element, so the
                         // page never claims audio focus (audio can stall video on
                         // some Android TV / Fire TV devices)
                         if (media.muted) view?.evaluateJavascript(MUTE_JS, null)
+                    }
+                }
+                // The watcher signals through the document title — no JS bridge needed.
+                webChromeClient = object : android.webkit.WebChromeClient() {
+                    override fun onReceivedTitle(view: WebView?, title: String?) {
+                        if (title == "pipup:playing" || title == "pipup:novideo") {
+                            onStreamFirstFrame()
+                        }
                     }
                 }
                 loadUrl(media.uri)
@@ -653,6 +669,57 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
             Log.w(LOG_TAG, "Unparseable color '$value', using $fallback")
             Color.parseColor(fallback)
         }
+
+        /// How long a web popup may keep its poster while the page never reports a
+        /// playing video (broken player, blocked JS). Cold WebRTC needs 3-4 s.
+        const val POSTER_FADE_CAP_MS = 8_000L
+
+        /// Reports through document.title: "pipup:playing" as soon as any <video>
+        /// renders frames, or "pipup:novideo" when no video element shows up shortly
+        /// after the first paint (an MJPEG/snapshot page - its paint IS the image).
+        const val VIDEO_WATCH_JS = """
+            (function() {
+                if (window.__pipupWatch) return;
+                window.__pipupWatch = true;
+                var done = false;
+                function signal(what) {
+                    if (done) return;
+                    done = true;
+                    document.title = 'pipup:' + what;
+                }
+                function hook(v) {
+                    if (v.__pipupHooked) return;
+                    v.__pipupHooked = true;
+                    if (!v.paused && v.currentTime > 0 && v.readyState >= 2) { signal('playing'); return; }
+                    ['playing', 'timeupdate', 'loadeddata'].forEach(function(ev) {
+                        v.addEventListener(ev, function() {
+                            if (v.currentTime > 0 || ev === 'playing') signal('playing');
+                        });
+                    });
+                }
+                function scan(root) {
+                    (root.querySelectorAll ? root.querySelectorAll('video') : []).forEach(hook);
+                    // go2rtc's video-rtc element hides its <video> in a shadow root
+                    (root.querySelectorAll ? root.querySelectorAll('*') : []).forEach(function(el) {
+                        if (el.shadowRoot) scan(el.shadowRoot);
+                    });
+                }
+                scan(document);
+                new MutationObserver(function() { scan(document); }).observe(
+                    document.documentElement, { childList: true, subtree: true });
+                setTimeout(function() {
+                    if (!done && document.querySelectorAll('video').length === 0) {
+                        var shadowVideo = false;
+                        try {
+                            document.querySelectorAll('*').forEach(function(el) {
+                                if (el.shadowRoot && el.shadowRoot.querySelector('video')) shadowVideo = true;
+                            });
+                        } catch (e) {}
+                        if (!shadowVideo) signal('novideo');
+                    }
+                }, 400);
+            })();
+        """
 
         const val MUTE_JS = """
             (function() {

--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,10 @@ streams) on your TV from your home-automation system, for **as long as you want*
   (e.g. a camera snapshot) shown over the stream area the moment the popup appears and faded out on
   the stream's first rendered frame. A live popup never opens as an empty box while the RTSP handshake
   or WebView start-up runs; the stream area takes the poster's aspect, so still and live line up. If the
-  stream never paints the poster simply stays. `/state.lastPopup.firstFrameMs` reports the time to first frame.
+  stream never paints the poster simply stays. On a web page that hosts a `<video>` (e.g. go2rtc's WebRTC
+  viewer) the fade waits for actual playback (since 0.20.0), not for the page paint — so WebRTC + poster
+  gives an instant still followed by near-realtime video. `/state.lastPopup.firstFrameMs` reports the time
+  to first frame.
 - **Screen on/off** (since 0.7.0) — `POST /power?state=on|off|toggle` wakes the TV or puts it in
   standby, without a second integration for ADB or HDMI-CEC. `/state` publishes what is actually
   possible on this device (`power.canSleep`, `power.sleepMethod`) instead of accepting a request it


### PR DESCRIPTION
The poster hand-over on `web_url` popups keyed on `onPageCommitVisible` — right for MJPEG (the paint *is* the image), wrong for player pages: go2rtc's WebRTC viewer paints its shell seconds before the stream flows, so the poster faded into a black page.

Now an injected watcher reports through `document.title`: `pipup:playing` once any `<video>` actually renders (hooked via events + MutationObserver; go2rtc appends a plain `<video>`, no shadow DOM), or `pipup:novideo` within ~0.4 s on pages without one (MJPEG/snapshot — behaviour unchanged). A hard 8 s cap keeps a broken page from pinning the poster. `firstFrameMs` now measures to actual playback on player pages.

Measured on a Fire TV: cold WebRTC → fade at 5.7 s (true video start), warm → 1.1 s; MJPEG regression ~1.0 s (unchanged). versionCode 52 / 0.20.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)