### PR TITLE
Poster fallback cap stands down when the page has a video element (0.20.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Original app by [rogro82](https://github.com/rogro82/PiPup).
 Every version below has a [GitHub release](https://github.com/mhoogenbosch/PiPup/releases) with the
 full story (English and Dutch) and the APK.
 
+## [v0.20.1] — 2026-08-31 (the fallback cap no longer races a slow player)
+### Fixed
+- 0.20.0's 8-second fallback could still fade the poster into a black player shell on a slow device: on a
+  TCL Google TV the page committed after 5.7 s and the cap fired at 13.7 s — occasionally just before the
+  video's first frame. The watcher now reports when it *finds* a `<video>` element, and a page with one is
+  exempt from the cap: its poster simply stays until the video actually plays. The cap (now 20 s) only
+  remains for pages whose watcher reports nothing at all (broken or blocked JS).
+
 ## [v0.20.0] — 2026-08-31 (the poster waits for the video on web popups)
 ### Changed
 - **On a `web_url` popup the poster now fades when the page's *video* actually plays**, not when the page

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "nl.rogro82.pipup"
         minSdkVersion 23
         targetSdkVersion 34
-        versionCode 52
-        versionName "0.20.0"
+        versionCode 53
+        versionName "0.20.1"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/app/src/main/java/nl/rogro82/pipup/PopupView.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PopupView.kt
@@ -552,6 +552,9 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
 
     private class Web(context: Context, popup: PopupProps, val media: PopupProps.Media.Web): PopupView(context, popup) {
         private var mWebView: WebView? = null
+        /// The watcher saw a <video> element on the page: "playing" will follow, so the
+        /// fallback cap must NOT fade the poster (a still beats a black player shell).
+        @Volatile private var mVideoElementFound = false
 
         init { create() }
 
@@ -581,9 +584,15 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
                     // the page has no video element — and only then the poster fades.
                     override fun onPageCommitVisible(view: WebView?, url: String?) {
                         view?.evaluateJavascript(VIDEO_WATCH_JS, null)
-                        // Hard cap: a broken page must not pin the poster forever; a
-                        // stale snapshot is still better than black, so fade late.
-                        view?.postDelayed({ onStreamFirstFrame() }, POSTER_FADE_CAP_MS)
+                        // Fallback cap for a page whose watcher never reports anything
+                        // (broken/blocked JS). When a <video> element WAS found, the cap
+                        // stands down: "playing" will follow, and until then the poster
+                        // is strictly better than the player's black shell. Measured on a
+                        // TCL: page commit 5.7 s + the old blind 8 s cap fired at 13.7 s,
+                        // sometimes just before the video - visible as a black flash.
+                        view?.postDelayed({
+                            if (!mVideoElementFound) onStreamFirstFrame()
+                        }, POSTER_FADE_CAP_MS)
                     }
                     override fun onPageFinished(view: WebView?, url: String?) {
                         // mute every (also dynamically added) media element, so the
@@ -595,8 +604,9 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
                 // The watcher signals through the document title — no JS bridge needed.
                 webChromeClient = object : android.webkit.WebChromeClient() {
                     override fun onReceivedTitle(view: WebView?, title: String?) {
-                        if (title == "pipup:playing" || title == "pipup:novideo") {
-                            onStreamFirstFrame()
+                        when (title) {
+                            "pipup:videofound" -> mVideoElementFound = true
+                            "pipup:playing", "pipup:novideo" -> onStreamFirstFrame()
                         }
                     }
                 }
@@ -670,9 +680,10 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
             Color.parseColor(fallback)
         }
 
-        /// How long a web popup may keep its poster while the page never reports a
-        /// playing video (broken player, blocked JS). Cold WebRTC needs 3-4 s.
-        const val POSTER_FADE_CAP_MS = 8_000L
+        /// Fallback fade for a page whose watcher never reports anything at all
+        /// (broken or blocked JS). A page with a discovered <video> is exempt: its
+        /// poster stays until the video actually plays, however long that takes.
+        const val POSTER_FADE_CAP_MS = 20_000L
 
         /// Reports through document.title: "pipup:playing" as soon as any <video>
         /// renders frames, or "pipup:novideo" when no video element shows up shortly
@@ -690,6 +701,7 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
                 function hook(v) {
                     if (v.__pipupHooked) return;
                     v.__pipupHooked = true;
+                    if (!done) document.title = 'pipup:videofound';
                     if (!v.paused && v.currentTime > 0 && v.readyState >= 2) { signal('playing'); return; }
                     ['playing', 'timeupdate', 'loadeddata'].forEach(function(ev) {
                         v.addEventListener(ev, function() {


### PR DESCRIPTION
Follow-up on 0.20.0, found during an on-TV demo: on a TCL the page commit came at 5.7 s and the blind 8 s cap (relative to commit) fired at 13.7 s — sometimes just before the video's first frame, visible as a black flash. The watcher now also signals `pipup:videofound`; pages with a video element are exempt from the cap (poster stays until real playback), and the 20 s cap only covers pages whose watcher reports nothing at all. Veranda: cold WebRTC fades at 7.1 s (real start), MJPEG unchanged (~1 s). versionCode 53 / 0.20.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)