### PR TITLE
Companion-version panel: recommended/minimum/connected ha-pipup in /state and on screen (0.21.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Original app by [rogro82](https://github.com/rogro82/PiPup).
 Every version below has a [GitHub release](https://github.com/mhoogenbosch/PiPup/releases) with the
 full story (English and Dutch) and the APK.
 
+## [v0.21.0] — 2026-08-31 (the TV tells you when the HA integration is behind)
+### Added
+- **Companion-version panel.** `/state` carries `haPipup`: `recommended` (the latest
+  [ha-pipup](https://github.com/mhoogenbosch/ha-pipup) release, fetched alongside the hourly self-update
+  check — the recommendation is by definition the latest release, nothing is maintained by hand),
+  `minimum` (oldest integration that can drive this app's full API; build-time constant, now 1.17.1) and
+  `connected` (ha-pipup ≥ 1.18.0 announces itself with an `X-HA-PiPup-Version` header on every request,
+  including the 15-second `/state` poll). The status screen shows the same as one line: ✓ up to date,
+  update available, too old, or not seen yet.
+
 ## [v0.20.1] — 2026-08-31 (the fallback cap no longer races a slow player)
 ### Fixed
 - 0.20.0's 8-second fallback could still fade the poster into a black player shell on a slow device: on a

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "nl.rogro82.pipup"
         minSdkVersion 23
         targetSdkVersion 34
-        versionCode 53
-        versionName "0.20.1"
+        versionCode 54
+        versionName "0.21.0"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/app/src/main/java/nl/rogro82/pipup/MainActivity.kt
+++ b/app/src/main/java/nl/rogro82/pipup/MainActivity.kt
@@ -255,6 +255,23 @@ class MainActivity : Activity() {
         sb.append("  •  popups: ").append(s.path("popupsShown").asLong(0))
         sb.append("  •  up: ").append(formatDuration(s.path("uptime").asLong(0)))
 
+        // Companion-integration line, straight from the same /state JSON HA sees.
+        val hp = s.path("haPipup")
+        if (hp.isObject) {
+            val rec = hp.path("recommended").takeIf { it.isTextual }?.asText()
+            val conn = hp.path("connected").takeIf { it.isTextual }?.asText()
+            val min = hp.path("minimum").takeIf { it.isTextual }?.asText()
+            when {
+                conn != null && min != null && UpdateManager.isNewer(min, conn) ->
+                    getString(R.string.status_ha_pipup_too_old, conn, min)
+                conn != null && rec != null && UpdateManager.isNewer(rec, conn) ->
+                    getString(R.string.status_ha_pipup_behind, conn, rec)
+                conn != null -> getString(R.string.status_ha_pipup_ok, conn)
+                rec != null -> getString(R.string.status_ha_pipup_recommended, rec)
+                else -> null
+            }?.let { sb.append("\n").append(it) }
+        }
+
         val last = s.path("lastPopup")
         if (last.isObject) {
             sb.append("\n\n").append(getString(R.string.status_last_popup))

--- a/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
@@ -50,6 +50,9 @@ class PiPupService : Service(), WebServer.Handler {
     // no public getter, so it is tracked from the DREAMING_STARTED/STOPPED broadcasts; unknown
     // (false) until the first transition after this service started.
     @Volatile private var mDreaming = false
+    /// Version the HA integration announced in its last request header (ha-pipup >= 1.18.0);
+    /// null until one arrives. Shown in /state and on the status screen ("connected").
+    @Volatile private var mHaPipupSeen: String? = null
     private val mDreamReceiver = object : android.content.BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
             mDreaming = intent?.action == Intent.ACTION_DREAMING_STARTED
@@ -851,6 +854,15 @@ class PiPupService : Service(), WebServer.Handler {
                 ?.let { (System.currentTimeMillis() - it) / 1000 },
             "error" to UpdateManager.lastError
         )
+        state["haPipup"] = mapOf(
+            // recommended = the latest ha-pipup release on GitHub, fetched with the
+            // hourly update check — it is never maintained by hand
+            "recommended" to UpdateManager.haPipupLatest,
+            // oldest integration that can drive this app's full API (build-time constant)
+            "minimum" to UpdateManager.MIN_HA_PIPUP,
+            // what is actually talking to us, from the request header; null = not seen
+            "connected" to mHaPipupSeen
+        )
         val last = mLastPopup
         if (last != null) {
             state["lastPopup"] = mapOf(
@@ -1029,6 +1041,9 @@ class PiPupService : Service(), WebServer.Handler {
 
     override fun handleHttpRequest(session: NanoHTTPD.IHTTPSession?): NanoHTTPD.Response {
         return session?.let {
+            // The HA integration announces itself on every request (ha-pipup >= 1.18.0) —
+            // including the 15s /state poll, so this fills in without any popup being sent.
+            session.headers["x-ha-pipup-version"]?.let { v -> mHaPipupSeen = v }
             when(session.method) {
                 NanoHTTPD.Method.GET -> {
                     when(session.uri) {

--- a/app/src/main/java/nl/rogro82/pipup/UpdateManager.kt
+++ b/app/src/main/java/nl/rogro82/pipup/UpdateManager.kt
@@ -35,6 +35,14 @@ object UpdateManager {
     private const val LOG_TAG = "PiPupUpdate"
     private const val RELEASES_URL =
         "https://api.github.com/repos/mhoogenbosch/PiPup/releases/latest"
+    private const val HA_PIPUP_RELEASES_URL =
+        "https://api.github.com/repos/mhoogenbosch/ha-pipup/releases/latest"
+
+    /// Oldest ha-pipup release that can drive EVERY field this app accepts (0.21.0 needs
+    /// the `padding` service field, added in ha-pipup 1.17.1). Bump ONLY when a new app
+    /// release adds request fields the integration must know about — part of the release
+    /// checklist, not something that tracks GitHub.
+    const val MIN_HA_PIPUP = "1.17.1"
     private const val INSTALL_ACTION = "nl.rogro82.pipup.INSTALL_RESULT"
     private const val NET_TIMEOUT_MS = 15000
     /// An attempt that has not concluded within this window is considered abandoned
@@ -43,6 +51,10 @@ object UpdateManager {
 
     /// Result of the most recent check; read by /state on the web-server thread.
     @Volatile var latestVersion: String? = null
+        private set
+    /// Latest ha-pipup release tag — BY DEFINITION the recommended integration version,
+    /// so there is nothing to keep in sync by hand. null until the first successful check.
+    @Volatile var haPipupLatest: String? = null
         private set
     @Volatile var downloadUrl: String? = null
         private set
@@ -102,8 +114,27 @@ object UpdateManager {
     val updateAvailable: Boolean
         get() = latestVersion?.let { isNewer(it, BuildConfig.VERSION_NAME) } ?: false
 
+    /// Refresh the recommended integration version (= the latest ha-pipup release).
+    /// Non-fatal by design: any miss (offline, rate limit) keeps the previous value.
+    private fun refreshHaPipupLatest() {
+        try {
+            val conn = (URL(HA_PIPUP_RELEASES_URL).openConnection() as HttpURLConnection).apply {
+                applyUpdaterTls(this)
+                connectTimeout = NET_TIMEOUT_MS
+                readTimeout = NET_TIMEOUT_MS
+                setRequestProperty("Accept", "application/vnd.github+json")
+                setRequestProperty("User-Agent", "PiPup/${BuildConfig.VERSION_NAME}")
+            }
+            if (conn.responseCode != 200) return
+            val body = conn.inputStream.bufferedReader().use { it.readText() }
+            Json.readTree(body).path("tag_name").asText("").removePrefix("v")
+                .takeIf { it.isNotBlank() }?.let { haPipupLatest = it }
+        } catch (_: Throwable) { /* keep the cached value */ }
+    }
+
     /// Query the GitHub releases API. Blocking — call from a background thread.
     fun check(): Boolean {
+        refreshHaPipupLatest()
         return try {
             val conn = (URL(RELEASES_URL).openConnection() as HttpURLConnection).apply {
                 applyUpdaterTls(this)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,5 +31,9 @@
     <string name="update_confirm_message">Press OK to open the system\'s install confirmation.</string>
     <string name="update_done_title">PiPup updated to %1$s</string>
     <string name="permission_install_blocked">This TV blocks turning it on from its settings screen. Grant it over adb:</string>
+    <string name="status_ha_pipup_ok">ha-pipup %1$s ✓ up to date</string>
+    <string name="status_ha_pipup_behind">ha-pipup %1$s — update available: %2$s</string>
+    <string name="status_ha_pipup_too_old">ha-pipup %1$s is too old for this app — install %2$s or newer</string>
+    <string name="status_ha_pipup_recommended">recommended ha-pipup: %1$s (no integration seen yet)</string>
     <string name="permission_overlay_blocked">This TV blocks turning it on from its settings screen. Grant it over adb:</string>
 </resources>

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,12 @@ streams) on your TV from your home-automation system, for **as long as you want*
   e.g. show a camera stream for exactly as long as there is motion.
 - **Popup `id` + update-in-place** — re-sending a notify with the same `id` and content only reschedules
   the removal timer without rebuilding the view, so a video/web stream keeps playing without flicker.
+- **Companion-version panel** (since 0.21.0) — `/state` carries a `haPipup` object: `recommended`
+  (the latest [ha-pipup](https://github.com/mhoogenbosch/ha-pipup) release, fetched with the hourly
+  update check — never maintained by hand), `minimum` (oldest integration that can drive this app's
+  full API, a build-time constant) and `connected` (what actually talks to us: ha-pipup ≥ 1.18.0
+  announces itself with an `X-HA-PiPup-Version` header on every request, including the 15s `/state`
+  poll). The app's own status screen shows the same line: ✓ up to date, update available, or too old.
 - **`/state` endpoint** — popup visibility, screen on/off (`screenOn`, since 0.2.3), popup counter,
   uptime, device info and a **stable device id** (since 0.2.5).
 - **`/cancel`** (existed upstream but undocumented) with optional selective `?id=`.


### PR DESCRIPTION
- UpdateManager fetches the latest ha-pipup release tag alongside the hourly self-update check (recommended version is by definition the latest release — nothing to maintain by hand); non-fatal, cached.
- MIN_HA_PIPUP build-time constant (1.17.1, oldest integration covering the full 0.21.0 API); bumped as part of the release checklist only when new request fields appear.
- The service remembers the X-HA-PiPup-Version request header (ha-pipup >= 1.18.0 sends it on every call, including the /state poll) and reports {recommended, minimum, connected} as /state.haPipup.
- MainActivity shows one line from that same JSON: up to date / update available / too old / not seen yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)