### PR TITLE
Self-update: apply the updater trust store to every redirect hop (0.21.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ Original app by [rogro82](https://github.com/rogro82/PiPup).
 Every version below has a [GitHub release](https://github.com/mhoogenbosch/PiPup/releases) with the
 full story (English and Dutch) and the APK.
 
+## [v0.21.1] — 2026-09-01 (self-update TLS fix reaches the redirect hop)
+### Fixed
+- 0.19.3's bundled ISRG Root X1 never protected the actual download: the GitHub asset URL redirects
+  (github.com → release-assets.githubusercontent.com) and `HttpURLConnection`'s automatic redirect makes a
+  fresh connection that does **not** inherit the custom `SSLSocketFactory` — so the ISRG-anchored hop was
+  still validated against the system store, and Android 6 kept failing with "Trust anchor not found" (#41).
+  The updater now follows redirects manually (max 5 hops) and applies its trust store to every hop.
+### Added
+- `/state.update.tlsFactory` reports which trust store the updater uses (`composite` = system + bundled
+  ISRG Root X1; `platform-default: <why>` when building it failed; `unbuilt` before the first check) — so
+  a TLS problem on a remote device is diagnosable without adb.
+
 ## [v0.21.0] — 2026-08-31 (the TV tells you when the HA integration is behind)
 ### Added
 - **Companion-version panel.** `/state` carries `haPipup`: `recommended` (the latest

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "nl.rogro82.pipup"
         minSdkVersion 23
         targetSdkVersion 34
-        versionCode 54
-        versionName "0.21.0"
+        versionCode 55
+        versionName "0.21.1"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
+++ b/app/src/main/java/nl/rogro82/pipup/PiPupService.kt
@@ -852,7 +852,9 @@ class PiPupService : Service(), WebServer.Handler {
             "silent" to UpdateManager.silentInstall,
             "checkedSecondsAgo" to UpdateManager.lastCheckedAt.takeIf { it > 0 }
                 ?.let { (System.currentTimeMillis() - it) / 1000 },
-            "error" to UpdateManager.lastError
+            "error" to UpdateManager.lastError,
+            // which trust store updater connections use; "unbuilt" until the first check
+            "tlsFactory" to UpdateManager.tlsFactoryKind
         )
         state["haPipup"] = mapOf(
             // recommended = the latest ha-pipup release on GitHub, fetched with the

--- a/app/src/main/java/nl/rogro82/pipup/UpdateManager.kt
+++ b/app/src/main/java/nl/rogro82/pipup/UpdateManager.kt
@@ -45,6 +45,7 @@ object UpdateManager {
     const val MIN_HA_PIPUP = "1.17.1"
     private const val INSTALL_ACTION = "nl.rogro82.pipup.INSTALL_RESULT"
     private const val NET_TIMEOUT_MS = 15000
+    private const val MAX_REDIRECTS = 5
     /// An attempt that has not concluded within this window is considered abandoned
     /// (typically: the on-TV confirmation was never accepted) and may be replaced.
     private const val INSTALL_TIMEOUT_MS = 15 * 60 * 1000L
@@ -61,6 +62,12 @@ object UpdateManager {
     @Volatile var lastCheckedAt: Long = 0L
         private set
     @Volatile var lastError: String? = null
+        private set
+    /// Which trust store the updater's connections use: "composite" (system + bundled
+    /// ISRG Root X1), "platform-default: <why>" when building the composite failed, or
+    /// "unbuilt" until the first connection forces the lazy build. Reported in /state
+    /// so a TLS problem on a remote device can be diagnosed without adb (#41).
+    @Volatile var tlsFactoryKind: String = "unbuilt"
         private set
 
     /// 0 = idle; otherwise the elapsedRealtime the current attempt started at. A
@@ -223,11 +230,41 @@ object UpdateManager {
 
             SSLContext.getInstance("TLS").apply {
                 init(null, arrayOf(composite), null)
-            }.socketFactory
+            }.socketFactory.also { tlsFactoryKind = "composite" }
         } catch (ex: Throwable) {
             Log.w(LOG_TAG, "legacy TLS factory unavailable, using platform default: ${ex.message}")
+            tlsFactoryKind = "platform-default: ${ex.message ?: ex.javaClass.simpleName}"
             null
         }
+    }
+
+    /// Open `startUrl` and follow redirects MANUALLY (max MAX_REDIRECTS hops), applying
+    /// the updater trust store to every hop. HttpURLConnection's automatic redirect
+    /// handling creates a fresh connection for the target that does NOT inherit this
+    /// connection's sslSocketFactory — so the GitHub asset download
+    /// (github.com → release-assets.githubusercontent.com, whose chain anchors on
+    /// ISRG Root X1) was validated against the system store only, and Android 6
+    /// failed it with "Trust anchor not found" even with the root bundled (#41).
+    private fun openWithRedirects(startUrl: String, readTimeoutMs: Int): HttpURLConnection {
+        var url = URL(startUrl)
+        for (hop in 0 until MAX_REDIRECTS) {
+            val conn = (url.openConnection() as HttpURLConnection).apply {
+                applyUpdaterTls(this)
+                connectTimeout = NET_TIMEOUT_MS
+                readTimeout = readTimeoutMs
+                instanceFollowRedirects = false
+                setRequestProperty("User-Agent", "PiPup/${BuildConfig.VERSION_NAME}")
+            }
+            if (conn.responseCode in 300..399) {
+                val location = conn.getHeaderField("Location")
+                    ?: return conn // malformed redirect: let the caller report the code
+                conn.disconnect()
+                url = URL(url, location) // URL(base, spec) also resolves relative Locations
+            } else {
+                return conn
+            }
+        }
+        throw Exception("too many redirects (> $MAX_REDIRECTS) for $startUrl")
     }
 
     /// Apply the updater trust store to a connection (no-op for plain http and on failure).
@@ -249,13 +286,7 @@ object UpdateManager {
         }
 
         return try {
-            val conn = (URL(url).openConnection() as HttpURLConnection).apply {
-                applyUpdaterTls(this)
-                connectTimeout = NET_TIMEOUT_MS
-                readTimeout = 60000
-                instanceFollowRedirects = true
-                setRequestProperty("User-Agent", "PiPup/${BuildConfig.VERSION_NAME}")
-            }
+            val conn = openWithRedirects(url, readTimeoutMs = 60000)
             if (conn.responseCode != 200) {
                 return "download failed: HTTP ${conn.responseCode}".also {
                     Log.w(LOG_TAG, it)


### PR DESCRIPTION
Fixes the remaining Android 6 self-update failure in #41: the asset download redirects from github.com (USERTrust-anchored — fine on Android 6) to release-assets.githubusercontent.com (ISRG-anchored), and HttpURLConnection's automatic redirect creates a fresh connection that does not inherit the per-instance SSLSocketFactory — so 0.19.3's bundled ISRG Root X1 never reached the hop that needed it. The updater now follows redirects manually (max 5, relative Locations resolved) and applies applyUpdaterTls per hop. Also adds /state.update.tlsFactory so a factory-construction failure on a device is visible remotely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)